### PR TITLE
Code clean-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         version:
           - '1.6'
           - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.8.11"
+version = "0.8.12"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.8.12"
+version = "0.8.13"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,9 @@ julia = "1.6"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Base64", "Compat", "Random", "StableRNGs", "Test"]
+test = ["Base64", "Random", "StableRNGs", "Test"]

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -8,7 +8,7 @@ using Base: AbstractCartesianIndex, OneTo, RangeIndex, ReinterpretArray, Reshape
             @propagate_inbounds, @_propagate_inbounds_meta
 
 import Base: axes, size, length, eltype, ndims, first, last, diff, isempty, union, sort!,
-                ==, *, +, -, /, \, copy, copyto!, similar, getindex, strides,
+                ==, *, +, -, /, \, copy, copyto!, similar, getproperty, getindex, strides,
                 unsafe_convert
 
 using Base.Broadcast: Broadcasted

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -9,7 +9,7 @@ using Base: AbstractCartesianIndex, OneTo, RangeIndex, ReinterpretArray, Reshape
 
 import Base: axes, size, length, eltype, ndims, first, last, diff, isempty, union, sort!,
                 ==, *, +, -, /, \, copy, copyto!, similar, getproperty, getindex, strides,
-                unsafe_convert
+                reverse, unsafe_convert
 
 using Base.Broadcast: Broadcasted
 
@@ -130,16 +130,16 @@ Base.@propagate_inbounds layout_getindex(A::AbstractArray, I::CartesianIndex) = 
 
 macro _layoutgetindex(Typ)
     esc(quote
-        @inline Base.getindex(A::$Typ, kr::Colon, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::Colon, jr::AbstractUnitRange) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::AbstractUnitRange, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::AbstractUnitRange, jr::AbstractUnitRange) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::AbstractVector, jr::AbstractVector) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::Colon, jr::AbstractVector) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::Colon, jr::Integer) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::AbstractVector, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::Integer, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
-        @inline Base.getindex(A::$Typ, kr::Integer, jr::AbstractVector) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::Colon, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::Colon, jr::AbstractUnitRange) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::AbstractUnitRange, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::AbstractUnitRange, jr::AbstractUnitRange) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::AbstractVector, jr::AbstractVector) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::Colon, jr::AbstractVector) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::Colon, jr::Integer) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::AbstractVector, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::Integer, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::Integer, jr::AbstractVector) = ArrayLayouts.layout_getindex(A, kr, jr)
     end)
 end
 
@@ -228,7 +228,7 @@ end
 
 
 _copyto!(_, _, dest::AbstractArray{T,N}, src::AbstractArray{V,N}) where {T,V,N} =
-    Base.invoke(copyto!, Tuple{AbstractArray{T,N},AbstractArray{V,N}}, dest, src)
+    invoke(copyto!, Tuple{AbstractArray{T,N},AbstractArray{V,N}}, dest, src)
 
 
 _copyto!(dest, src) = _copyto!(MemoryLayout(dest), MemoryLayout(src), dest, src)
@@ -266,7 +266,7 @@ function zero!(_, A::AbstractArray{<:AbstractArray})
     A
 end
 
-_norm(_, A, p) = Base.invoke(norm, Tuple{Any,Real}, A, p)
+_norm(_, A, p) = invoke(norm, Tuple{Any,Real}, A, p)
 LinearAlgebra.norm(A::LayoutArray, p::Real=2) = _norm(MemoryLayout(A), A, p)
 LinearAlgebra.norm(A::SubArray{<:Any,N,<:LayoutArray}, p::Real=2) where N = _norm(MemoryLayout(A), A, p)
 
@@ -338,7 +338,7 @@ layout_replace_in_print_matrix(_, A, i, j, s) =
     i in colsupport(A,j) ? s : Base.replace_with_centered_mark(s)
 
 Base.replace_in_print_matrix(A::Union{LayoutVector,
-                                        LayoutMatrix,
+                                      LayoutMatrix,
                                       UpperTriangular{<:Any,<:LayoutMatrix},
                                       UnitUpperTriangular{<:Any,<:LayoutMatrix},
                                       LowerTriangular{<:Any,<:LayoutMatrix},

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -39,6 +39,13 @@ import LinearAlgebra: AbstractTriangular, AbstractQ, QRCompactWYQ, QRPackedQ, ch
                         norm2, norm1, normInf, normMinusInf, qr, lu, qr!, lu!, AdjOrTrans, HermOrSym, AdjointAbsVec,
                         TransposeAbsVec, cholcopy, checknonsingular, _apply_ipiv_rows!, ipiv2perm, RealHermSymComplexHerm, chkfullrank
 
+if VERSION >= v"1.9-"
+    using LinearAlgebra: AdjointQ
+    AdjointQtype{T} = AdjointQ{T}
+else
+    AdjointQtype{T} = Adjoint{T,<:AbstractQ}
+end
+
 import LinearAlgebra.BLAS: BlasFloat, BlasReal, BlasComplex
 
 import FillArrays: AbstractFill, getindex_value, axes_print_matrix_row, _copy_oftype

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -21,8 +21,6 @@ using LinearAlgebra: AbstractTriangular, AbstractQ, QRCompactWYQ, QRPackedQ, che
                         AdjOrTrans, HermOrSym, RealHermSymComplexHerm, AdjointAbsVec, TransposeAbsVec,
                         checknonsingular, _apply_ipiv_rows!, ipiv2perm, chkfullrank
 
-AdjointQtype{T} = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ{T} : Adjoint{T,<:AbstractQ}
-
 using LinearAlgebra.BLAS: BlasFloat, BlasReal, BlasComplex
 
 using FillArrays: AbstractFill, getindex_value, axes_print_matrix_row, _copy_oftype

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -39,12 +39,7 @@ import LinearAlgebra: AbstractTriangular, AbstractQ, QRCompactWYQ, QRPackedQ, ch
                         norm2, norm1, normInf, normMinusInf, qr, lu, qr!, lu!, AdjOrTrans, HermOrSym, AdjointAbsVec,
                         TransposeAbsVec, cholcopy, checknonsingular, _apply_ipiv_rows!, ipiv2perm, RealHermSymComplexHerm, chkfullrank
 
-if VERSION >= v"1.9-"
-    using LinearAlgebra: AdjointQ
-    AdjointQtype{T} = AdjointQ{T}
-else
-    AdjointQtype{T} = Adjoint{T,<:AbstractQ}
-end
+AdjointQtype{T} = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ{T} : Adjoint{T,<:AbstractQ}
 
 import LinearAlgebra.BLAS: BlasFloat, BlasReal, BlasComplex
 

--- a/src/cumsum.jl
+++ b/src/cumsum.jl
@@ -31,7 +31,7 @@ last(r::RangeCumsum) = sum(r.range)
 diff(r::RangeCumsum) = r.range[2:end]
 isempty(r::RangeCumsum) = isempty(r.range)
 
-union(a::RangeCumsum{<:Any,<:Base.OneTo}, b::RangeCumsum{<:Any,<:Base.OneTo}) = 
-    RangeCumsum(Base.OneTo(max(last(a.range),last(b.range))))
+union(a::RangeCumsum{<:Any,<:OneTo}, b::RangeCumsum{<:Any,<:OneTo}) = 
+    RangeCumsum(OneTo(max(last(a.range), last(b.range))))
 
 sort!(a::RangeCumsum{<:Any,<:AbstractUnitRange}) = a

--- a/src/factorizations.jl
+++ b/src/factorizations.jl
@@ -300,12 +300,12 @@ function materialize!(M::Rmul{<:Any,<:AdjQRPackedQLayout})
 end
 
 
-__qr(layout, lengths, A; kwds...) = Base.invoke(qr, Tuple{AbstractMatrix{eltype(A)}}, A; kwds...)
+__qr(layout, lengths, A; kwds...) = invoke(qr, Tuple{AbstractMatrix{eltype(A)}}, A; kwds...)
 _qr(layout, axes, A; kwds...) = __qr(layout, map(length, axes), A; kwds...)
-_qr(layout, axes, A, pivot::P; kwds...) where P = Base.invoke(qr, Tuple{AbstractMatrix{eltype(A)},P}, A, pivot; kwds...)
+_qr(layout, axes, A, pivot::P; kwds...) where P = invoke(qr, Tuple{AbstractMatrix{eltype(A)},P}, A, pivot; kwds...)
 _qr!(layout, axes, A, args...; kwds...) = error("Overload _qr!(::$(typeof(layout)), axes, A)")
-_lu(layout, axes, A; kwds...) = Base.invoke(lu, Tuple{AbstractMatrix{eltype(A)}}, A; kwds...)
-_lu(layout, axes, A, pivot::P; kwds...) where P = Base.invoke(lu, Tuple{AbstractMatrix{eltype(A)},P}, A, pivot; kwds...)
+_lu(layout, axes, A; kwds...) = invoke(lu, Tuple{AbstractMatrix{eltype(A)}}, A; kwds...)
+_lu(layout, axes, A, pivot::P; kwds...) where P = invoke(lu, Tuple{AbstractMatrix{eltype(A)},P}, A, pivot; kwds...)
 _lu!(layout, axes, A, args...; kwds...) = error("Overload _lu!(::$(typeof(layout)), axes, A)")
 _cholesky(layout, axes, A, ::CNoPivot=CNoPivot(); check::Bool = true) = cholesky!(cholcopy(A); check = check)
 _cholesky(layout, axes, A, ::CRowMaximum; tol = 0.0, check::Bool = true) = cholesky!(cholcopy(A), CRowMaximum(); tol = tol, check = check)
@@ -384,7 +384,7 @@ function _cholesky!(::SymmetricLayout{<:AbstractColumnMajor}, axes, A::AbstractM
 end
 
 
-_inv_eye(_, ::Type{T}, axs::NTuple{2,Base.OneTo{Int}}) where T = Matrix{T}(I, map(length,axs)...)
+_inv_eye(_, ::Type{T}, axs::NTuple{2,OneTo{Int}}) where T = Matrix{T}(I, map(length,axs)...)
 function _inv_eye(A, ::Type{T}, (rows,cols)) where T
     dest = zero!(similar(A, T, (cols,rows)))
     dest[diagind(dest)] .= one(T)
@@ -414,7 +414,7 @@ macro _layoutfactorizations(Typ)
         LinearAlgebra.lu(A::$Typ{T}; kwds...) where T = ArrayLayouts._lu(ArrayLayouts.MemoryLayout(A), axes(A), A; kwds...)
         LinearAlgebra.lu!(A::$Typ, args...; kwds...) = ArrayLayouts._lu!(ArrayLayouts.MemoryLayout(A), axes(A), A, args...; kwds...)
         LinearAlgebra.factorize(A::$Typ) = ArrayLayouts._factorize(ArrayLayouts.MemoryLayout(A), axes(A), A)
-        LinearAlgebra.inv(A::$Typ) = ArrayLayouts._inv(ArrayLayouts.MemoryLayout(A), axes(A), A)
+        Base.inv(A::$Typ) = ArrayLayouts._inv(ArrayLayouts.MemoryLayout(A), axes(A), A)
         LinearAlgebra.ldiv!(L::LU{<:Any,<:$Typ}, B) = ArrayLayouts.ldiv!(L, B)
         LinearAlgebra.ldiv!(L::LU{<:Any,<:$Typ}, B::$Typ) = ArrayLayouts.ldiv!(L, B)
     end)

--- a/src/factorizations.jl
+++ b/src/factorizations.jl
@@ -196,14 +196,14 @@ end
 
 
 ### QcB
-materialize!(M::Lmul{<:AdjQRPackedQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractStridedLayout,<:AdjointQtype{T},<:AbstractVecOrMat{T}}) where T<:BlasFloat =
-    (A = parent(M.A); LAPACK.ormqr!('L','T',A.factors,A.τ,M.B))
-materialize!(M::Lmul{<:AdjQRPackedQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractStridedLayout,<:AdjointQtype{T},<:AbstractVecOrMat{T}}) where T<:BlasComplex =
-    (A = parent(M.A); LAPACK.ormqr!('L','C',A.factors,A.τ,M.B))
-materialize!(M::Lmul{<:AdjQRCompactWYQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractStridedLayout,<:AdjointQtype{T},<:AbstractVecOrMat{T}}) where T<:BlasFloat =
-    (A = parent(M.A); LAPACK.gemqrt!('L','T',A.factors,A.T,M.B))
-materialize!(M::Lmul{<:AdjQRCompactWYQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractStridedLayout,<:AdjointQtype{T},<:AbstractVecOrMat{T}}) where T<:BlasComplex =
-    (A = parent(M.A); LAPACK.gemqrt!('L','C',A.factors,A.T,M.B))
+materialize!(M::Lmul{<:AdjQRPackedQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractStridedLayout,<:AbstractMatrix{T},<:AbstractVecOrMat{T}}) where T<:BlasFloat =
+    (A = M.A.parent; LAPACK.ormqr!('L','T',A.factors,A.τ,M.B))
+materialize!(M::Lmul{<:AdjQRPackedQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractStridedLayout,<:AbstractMatrix{T},<:AbstractVecOrMat{T}}) where T<:BlasComplex =
+    (A = M.A.parent; LAPACK.ormqr!('L','C',A.factors,A.τ,M.B))
+materialize!(M::Lmul{<:AdjQRCompactWYQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractStridedLayout,<:AbstractMatrix{T},<:AbstractVecOrMat{T}}) where T<:BlasFloat =
+    (A = M.A.parent; LAPACK.gemqrt!('L','T',A.factors,A.T,M.B))
+materialize!(M::Lmul{<:AdjQRCompactWYQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractStridedLayout,<:AbstractMatrix{T},<:AbstractVecOrMat{T}}) where T<:BlasComplex =
+    (A = M.A.parent; LAPACK.gemqrt!('L','C',A.factors,A.T,M.B))
 function materialize!(M::Lmul{<:AdjQRPackedQLayout})
     adjA,B = M.A, M.B
     require_one_based_indexing(B)
@@ -264,14 +264,14 @@ function materialize!(M::Rmul{<:Any,<:QRPackedQLayout})
 end
 
 ### AQc
-materialize!(M::Rmul{<:AbstractStridedLayout,<:AdjQRPackedQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractVecOrMat{T},<:AdjointQtype{T}}) where T<:BlasReal =
-    (B = parent(M.B); LAPACK.ormqr!('R','T',B.factors,B.τ,M.A))
-materialize!(M::Rmul{<:AbstractStridedLayout,<:AdjQRPackedQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractVecOrMat{T},<:AdjointQtype{T}}) where T<:BlasComplex =
-    (B = parent(M.B); LAPACK.ormqr!('R','C',B.factors,B.τ,M.A))
-materialize!(M::Rmul{<:AbstractStridedLayout,<:AdjQRCompactWYQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractVecOrMat{T},<:AdjointQtype{T}}) where T<:BlasReal =
-    (B = parent(M.B); LAPACK.gemqrt!('R','T',B.factors,B.T,M.A))
-materialize!(M::Rmul{<:AbstractStridedLayout,<:AdjQRCompactWYQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractVecOrMat{T},<:AdjointQtype{T}}) where T<:BlasComplex =
-    (B = parent(M.B); LAPACK.gemqrt!('R','C',B.factors,B.T,M.A))
+materialize!(M::Rmul{<:AbstractStridedLayout,<:AdjQRPackedQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractVecOrMat{T},<:AbstractMatrix{T}}) where T<:BlasReal =
+    (B = M.B.parent; LAPACK.ormqr!('R','T',B.factors,B.τ,M.A))
+materialize!(M::Rmul{<:AbstractStridedLayout,<:AdjQRPackedQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractVecOrMat{T},<:AbstractMatrix{T}}) where T<:BlasComplex =
+    (B = M.B.parent; LAPACK.ormqr!('R','C',B.factors,B.τ,M.A))
+materialize!(M::Rmul{<:AbstractStridedLayout,<:AdjQRCompactWYQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractVecOrMat{T},<:AbstractMatrix{T}}) where T<:BlasReal =
+    (B = M.B.parent; LAPACK.gemqrt!('R','T',B.factors,B.T,M.A))
+materialize!(M::Rmul{<:AbstractStridedLayout,<:AdjQRCompactWYQLayout{<:AbstractStridedLayout,<:AbstractStridedLayout},<:AbstractVecOrMat{T},<:AbstractMatrix{T}}) where T<:BlasComplex =
+    (B = M.B.parent; LAPACK.gemqrt!('R','C',B.factors,B.T,M.A))
 function materialize!(M::Rmul{<:Any,<:AdjQRPackedQLayout})
     A,adjQ = M.A,M.B
     Q = parent(adjQ)

--- a/src/ldiv.jl
+++ b/src/ldiv.jl
@@ -105,8 +105,8 @@ const BlasMatLdivMat{styleA, styleB, T<:BlasFloat} = MatLdivMat{styleA, styleB, 
 const MatRdivMat{styleA, styleB, T, V} = Rdiv{styleA, styleB, <:AbstractMatrix{T}, <:AbstractMatrix{V}}
 const BlasMatRdivMat{styleA, styleB, T<:BlasFloat} = MatRdivMat{styleA, styleB, T, T}
 
-materialize!(M::Ldiv{ScalarLayout}) = Base.invoke(LinearAlgebra.ldiv!, Tuple{Number,AbstractArray}, M.A, M.B)
-materialize!(M::Rdiv{<:Any,ScalarLayout}) = Base.invoke(LinearAlgebra.rdiv!, Tuple{AbstractArray,Number}, M.A, M.B)
+materialize!(M::Ldiv{ScalarLayout}) = invoke(LinearAlgebra.ldiv!, Tuple{Number,AbstractArray}, M.A, M.B)
+materialize!(M::Rdiv{<:Any,ScalarLayout}) = invoke(LinearAlgebra.rdiv!, Tuple{AbstractArray,Number}, M.A, M.B)
 
 function materialize!(M::Ldiv{ScalarLayout,<:SymmetricLayout})
     ldiv!(M.A, symmetricdata(M.B))
@@ -139,42 +139,42 @@ macro _layoutldiv(Typ)
         LinearAlgebra.ldiv!(A::Bidiagonal, B::$Typ) = ArrayLayouts.ldiv!(A,B)
 
 
-        Base.:\(A::$Typ, x::AbstractVector) = ArrayLayouts.ldiv(A,x)
-        Base.:\(A::$Typ, x::AbstractMatrix) = ArrayLayouts.ldiv(A,x)
+        (\)(A::$Typ, x::AbstractVector) = ArrayLayouts.ldiv(A,x)
+        (\)(A::$Typ, x::AbstractMatrix) = ArrayLayouts.ldiv(A,x)
 
-        Base.:\(x::AbstractMatrix, A::$Typ) = ArrayLayouts.ldiv(x,A)
-        Base.:\(x::UpperTriangular, A::$Typ) = ArrayLayouts.ldiv(x,A)
-        Base.:\(x::LowerTriangular, A::$Typ) = ArrayLayouts.ldiv(x,A)
-        Base.:\(x::Diagonal, A::$Typ) = ArrayLayouts.ldiv(x,A)
+        (\)(x::AbstractMatrix, A::$Typ) = ArrayLayouts.ldiv(x,A)
+        (\)(x::UpperTriangular, A::$Typ) = ArrayLayouts.ldiv(x,A)
+        (\)(x::LowerTriangular, A::$Typ) = ArrayLayouts.ldiv(x,A)
+        (\)(x::Diagonal, A::$Typ) = ArrayLayouts.ldiv(x,A)
 
-        Base.:\(A::Bidiagonal{<:Number}, B::$Typ{<:Number}) = ArrayLayouts.ldiv(A,B)
-        Base.:\(A::Bidiagonal, B::$Typ) = ArrayLayouts.ldiv(A,B)
-        Base.:\(transA::Transpose{<:Number,<:Bidiagonal{<:Number}}, B::$Typ{<:Number}) = ArrayLayouts.ldiv(transA,B)
-        Base.:\(transA::Transpose{<:Any,<:Bidiagonal}, B::$Typ) = ArrayLayouts.ldiv(transA,B)
-        Base.:\(adjA::Adjoint{<:Number,<:Bidiagonal{<:Number}}, B::$Typ{<:Number}) = ArrayLayouts.ldiv(adjA,B)
-        Base.:\(adjA::Adjoint{<:Any,<:Bidiagonal}, B::$Typ) = ArrayLayouts.ldiv(adjA,B)
+        (\)(A::Bidiagonal{<:Number}, B::$Typ{<:Number}) = ArrayLayouts.ldiv(A,B)
+        (\)(A::Bidiagonal, B::$Typ) = ArrayLayouts.ldiv(A,B)
+        (\)(transA::Transpose{<:Number,<:Bidiagonal{<:Number}}, B::$Typ{<:Number}) = ArrayLayouts.ldiv(transA,B)
+        (\)(transA::Transpose{<:Any,<:Bidiagonal}, B::$Typ) = ArrayLayouts.ldiv(transA,B)
+        (\)(adjA::Adjoint{<:Number,<:Bidiagonal{<:Number}}, B::$Typ{<:Number}) = ArrayLayouts.ldiv(adjA,B)
+        (\)(adjA::Adjoint{<:Any,<:Bidiagonal}, B::$Typ) = ArrayLayouts.ldiv(adjA,B)
 
-        Base.:\(x::$Typ, A::$Typ) = ArrayLayouts.ldiv(x,A)
+        (\)(x::$Typ, A::$Typ) = ArrayLayouts.ldiv(x,A)
 
-        Base.:/(A::$Typ, x::AbstractVector) = ArrayLayouts.rdiv(A,x)
-        Base.:/(A::$Typ, x::AbstractMatrix) = ArrayLayouts.rdiv(A,x)
+        (/)(A::$Typ, x::AbstractVector) = ArrayLayouts.rdiv(A,x)
+        (/)(A::$Typ, x::AbstractMatrix) = ArrayLayouts.rdiv(A,x)
 
-        Base.:/(x::AbstractMatrix, A::$Typ) = ArrayLayouts.rdiv(x,A)
-        Base.:/(D::Diagonal, A::$Typ) = ArrayLayouts.rdiv(D,A)
-        Base.:/(A::$Typ, D::Diagonal) = ArrayLayouts.rdiv(A,D)
+        (/)(x::AbstractMatrix, A::$Typ) = ArrayLayouts.rdiv(x,A)
+        (/)(D::Diagonal, A::$Typ) = ArrayLayouts.rdiv(D,A)
+        (/)(A::$Typ, D::Diagonal) = ArrayLayouts.rdiv(A,D)
 
-        Base.:/(x::$Typ, A::$Typ) = ArrayLayouts.rdiv(x,A)
+        (/)(x::$Typ, A::$Typ) = ArrayLayouts.rdiv(x,A)
     end
     if Typ ≠ :LayoutVector
         ret = quote
             $ret
-            Base.:\(A::$Typ, x::LayoutVector) = ArrayLayouts.ldiv(A,x)
+            (\)(A::$Typ, x::LayoutVector) = ArrayLayouts.ldiv(A,x)
         end
     end
     if Typ ≠ :LayoutMatrix
         ret = quote
             $ret
-            Base.:\(A::$Typ, x::LayoutMatrix) = ArrayLayouts.ldiv(A,x)
+            (\)(A::$Typ, x::LayoutMatrix) = ArrayLayouts.ldiv(A,x)
         end
     end
     esc(ret)

--- a/src/ldiv.jl
+++ b/src/ldiv.jl
@@ -133,6 +133,8 @@ macro _layoutldiv(Typ)
         LinearAlgebra.ldiv!(A::$Typ, x::StridedMatrix) = ArrayLayouts.ldiv!(A,x)
 
         LinearAlgebra.ldiv!(A::Factorization, x::$Typ) = ArrayLayouts.ldiv!(A,x)
+        LinearAlgebra.ldiv!(A::LU, x::$Typ) = ArrayLayouts.ldiv!(A,x)
+        LinearAlgebra.ldiv!(A::Cholesky, x::$Typ) = ArrayLayouts.ldiv!(A,x)
 
         LinearAlgebra.ldiv!(A::Bidiagonal, B::$Typ) = ArrayLayouts.ldiv!(A,B)
 

--- a/src/ldiv.jl
+++ b/src/ldiv.jl
@@ -144,7 +144,9 @@ macro _layoutldiv(Typ)
 
         (\)(x::AbstractMatrix, A::$Typ) = ArrayLayouts.ldiv(x,A)
         (\)(x::UpperTriangular, A::$Typ) = ArrayLayouts.ldiv(x,A)
+        (\)(x::UnitUpperTriangular, A::$Typ) = ArrayLayouts.ldiv(x,A)
         (\)(x::LowerTriangular, A::$Typ) = ArrayLayouts.ldiv(x,A)
+        (\)(x::UnitLowerTriangular, A::$Typ) = ArrayLayouts.ldiv(x,A)
         (\)(x::Diagonal, A::$Typ) = ArrayLayouts.ldiv(x,A)
 
         (\)(A::Bidiagonal{<:Number}, B::$Typ{<:Number}) = ArrayLayouts.ldiv(A,B)

--- a/src/lmul.jl
+++ b/src/lmul.jl
@@ -70,8 +70,8 @@ copyto!(dest::AbstractArray, M::Rmul) = _rmul_copyto!(dest, M)
 materialize!(M::Lmul) = LinearAlgebra.lmul!(M.A,M.B)
 materialize!(M::Rmul) = LinearAlgebra.rmul!(M.A,M.B)
 
-materialize!(M::Lmul{ScalarLayout}) = Base.invoke(LinearAlgebra.lmul!, Tuple{Number,AbstractArray}, M.A, M.B)
-materialize!(M::Rmul{<:Any,ScalarLayout}) = Base.invoke(LinearAlgebra.rmul!, Tuple{AbstractArray,Number}, M.A, M.B)
+materialize!(M::Lmul{ScalarLayout}) = invoke(LinearAlgebra.lmul!, Tuple{Number,AbstractArray}, M.A, M.B)
+materialize!(M::Rmul{<:Any,ScalarLayout}) = invoke(LinearAlgebra.rmul!, Tuple{AbstractArray,Number}, M.A, M.B)
 
 function materialize!(M::Lmul{ScalarLayout,<:SymmetricLayout})
     lmul!(M.A, symmetricdata(M.B))

--- a/src/lmul.jl
+++ b/src/lmul.jl
@@ -27,10 +27,10 @@ end
 
 
 
-const MatLmulVec{StyleA,StyleB} = Lmul{StyleA,StyleB,<:AbstractMatrix,<:AbstractVector}
+const MatLmulVec{StyleA,StyleB} = Lmul{StyleA,StyleB,<:Union{AbstractMatrix,AbstractQ},<:AbstractVector}
 const MatLmulMat{StyleA,StyleB} = Lmul{StyleA,StyleB,<:AbstractMatrix,<:AbstractMatrix}
 
-const BlasMatLmulVec{StyleA,StyleB,T<:BlasFloat} = Lmul{StyleA,StyleB,<:AbstractMatrix{T},<:AbstractVector{T}}
+const BlasMatLmulVec{StyleA,StyleB,T<:BlasFloat} = Lmul{StyleA,StyleB,<:Union{AbstractMatrix{T},AbstractQ{T}},<:AbstractVector{T}}
 const BlasMatLmulMat{StyleA,StyleB,T<:BlasFloat} = Lmul{StyleA,StyleB,<:AbstractMatrix{T},<:AbstractMatrix{T}}
 
 const MatRmulMat{StyleA,StyleB} = Rmul{StyleA,StyleB,<:AbstractMatrix,<:AbstractMatrix}

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -282,7 +282,7 @@ struct DualLayout{ML<:MemoryLayout} <: MemoryLayout end
 MemoryLayout(::Type{Transpose{T,P}}) where {T,P} = transposelayout(MemoryLayout(P))
 MemoryLayout(::Type{Adjoint{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
 if isdefined(LinearAlgebra, :AdjointQ)
-    MemoryLayout(::Type{AdjointQ{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
+    MemoryLayout(::Type{LinearAlgebra.AdjointQ{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
 end
 MemoryLayout(::Type{AdjointAbsVec{T,P}}) where {T,P<:AbstractVector} = DualLayout{typeof(adjointlayout(T,MemoryLayout(P)))}()
 MemoryLayout(::Type{TransposeAbsVec{T,P}}) where {T,P<:AbstractVector} = DualLayout{typeof(transposelayout(MemoryLayout(P)))}()

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -281,9 +281,6 @@ struct DualLayout{ML<:MemoryLayout} <: MemoryLayout end
 
 MemoryLayout(::Type{Transpose{T,P}}) where {T,P} = transposelayout(MemoryLayout(P))
 MemoryLayout(::Type{Adjoint{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
-if isdefined(LinearAlgebra, :AdjointQ)
-    MemoryLayout(::Type{LinearAlgebra.AdjointQ{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
-end
 MemoryLayout(::Type{AdjointAbsVec{T,P}}) where {T,P<:AbstractVector} = DualLayout{typeof(adjointlayout(T,MemoryLayout(P)))}()
 MemoryLayout(::Type{TransposeAbsVec{T,P}}) where {T,P<:AbstractVector} = DualLayout{typeof(transposelayout(MemoryLayout(P)))}()
 

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -281,7 +281,7 @@ struct DualLayout{ML<:MemoryLayout} <: MemoryLayout end
 
 MemoryLayout(::Type{Transpose{T,P}}) where {T,P} = transposelayout(MemoryLayout(P))
 MemoryLayout(::Type{Adjoint{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
-if VERSION >= v"1.9-"
+if isdefined(LinearAlgebra, :AdjointQ)
     MemoryLayout(::Type{AdjointQ{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
 end
 MemoryLayout(::Type{AdjointAbsVec{T,P}}) where {T,P<:AbstractVector} = DualLayout{typeof(adjointlayout(T,MemoryLayout(P)))}()

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -281,6 +281,9 @@ struct DualLayout{ML<:MemoryLayout} <: MemoryLayout end
 
 MemoryLayout(::Type{Transpose{T,P}}) where {T,P} = transposelayout(MemoryLayout(P))
 MemoryLayout(::Type{Adjoint{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
+if VERSION >= v"1.9-"
+    MemoryLayout(::Type{AdjointQ{T,P}}) where {T,P} = adjointlayout(T, MemoryLayout(P))
+end
 MemoryLayout(::Type{AdjointAbsVec{T,P}}) where {T,P<:AbstractVector} = DualLayout{typeof(adjointlayout(T,MemoryLayout(P)))}()
 MemoryLayout(::Type{TransposeAbsVec{T,P}}) where {T,P<:AbstractVector} = DualLayout{typeof(transposelayout(MemoryLayout(P)))}()
 

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -347,13 +347,13 @@ function permutelayout(layout::Union{IncreasingStrides,DecreasingStrides}, ::Val
     return StridedLayout()
 end
 
-Base.reverse(::DenseRowMajor) = DenseColumnMajor()
-Base.reverse(::RowMajor) = ColumnMajor()
-Base.reverse(::DenseColumnMajor) = DenseRowMajor()
-Base.reverse(::ColumnMajor) = RowMajor()
-Base.reverse(::IncreasingStrides) = DecreasingStrides()
-Base.reverse(::DecreasingStrides) = IncreasingStrides()
-Base.reverse(::AbstractStridedLayout) = StridedLayout()
+reverse(::DenseRowMajor) = DenseColumnMajor()
+reverse(::RowMajor) = ColumnMajor()
+reverse(::DenseColumnMajor) = DenseRowMajor()
+reverse(::ColumnMajor) = RowMajor()
+reverse(::IncreasingStrides) = DecreasingStrides()
+reverse(::DecreasingStrides) = IncreasingStrides()
+reverse(::AbstractStridedLayout) = StridedLayout()
 
 
 # MemoryLayout of Symmetric/Hermitian
@@ -498,7 +498,7 @@ triangularlayout(::Type{Tri}, ::MemoryLayout) where Tri = Tri{UnknownLayout}()
 triangularlayout(::Type{Tri}, ::ML) where {Tri, ML<:AbstractColumnMajor} = Tri{ML}()
 triangularlayout(::Type{Tri}, ::ML) where {Tri, ML<:AbstractRowMajor} = Tri{ML}()
 triangularlayout(::Type{Tri}, ::ML) where {Tri, ML<:ConjLayout{<:AbstractRowMajor}} = Tri{ML}()
-sublayout(layout::TriangularLayout, ::Type{<:Tuple{<:Union{Slice,Base.OneTo},<:Union{Slice,Base.OneTo}}}) = layout
+sublayout(layout::TriangularLayout, ::Type{<:Tuple{<:Union{Slice,OneTo},<:Union{Slice,OneTo}}}) = layout
 conjlayout(::Type{<:Complex}, ::TriangularLayout{UPLO,UNIT,ML}) where {UPLO,UNIT,ML} =
     TriangularLayout{UPLO,UNIT,ConjLayout{ML}}()
 
@@ -512,7 +512,7 @@ end
 triangulardata(A::AbstractTriangular) = parent(A)
 triangulardata(A::Adjoint) = Adjoint(triangulardata(parent(A)))
 triangulardata(A::Transpose) = Transpose(triangulardata(parent(A)))
-triangulardata(A::SubArray{<:Any,2,<:Any,<:Tuple{<:Union{Slice,Base.OneTo},<:Union{Slice,Base.OneTo}}}) =
+triangulardata(A::SubArray{<:Any,2,<:Any,<:Tuple{<:Union{Slice,OneTo},<:Union{Slice,OneTo}}}) =
     view(triangulardata(parent(A)), parentindices(A)...)
 
 ###

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -196,7 +196,7 @@ macro layoutmul(Typ)
 
         Base.:*(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
         Base.:*(A::$Typ, B::LinearAlgebra.AbstractQ) = ArrayLayouts.mul(A,B)
-        if VERSION >= v"1.9-"
+        if isdefined(LinearAlgebra, AdjointQ)
             Base.:*(A::LinearAlgebra.AdjointQ, B::$Typ) = ArrayLayouts.mul(A,B)
             Base.:*(A::$Typ, B::LinearAlgebra.AdjointQ) = ArrayLayouts.mul(A,B)
         end            

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -196,7 +196,7 @@ macro layoutmul(Typ)
 
         Base.:*(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
         Base.:*(A::$Typ, B::LinearAlgebra.AbstractQ) = ArrayLayouts.mul(A,B)
-        if isdefined(LinearAlgebra, AdjointQ)
+        if isdefined(LinearAlgebra, :AdjointQ)
             Base.:*(A::LinearAlgebra.AdjointQ, B::$Typ) = ArrayLayouts.mul(A,B)
             Base.:*(A::$Typ, B::LinearAlgebra.AdjointQ) = ArrayLayouts.mul(A,B)
         end            

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -196,6 +196,10 @@ macro layoutmul(Typ)
 
         Base.:*(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
         Base.:*(A::$Typ, B::LinearAlgebra.AbstractQ) = ArrayLayouts.mul(A,B)
+        if VERSION >= v"1.9-"
+            Base.:*(A::LinearAlgebra.AdjointQ, B::$Typ) = ArrayLayouts.mul(A,B)
+            Base.:*(A::$Typ, B::LinearAlgebra.AdjointQ) = ArrayLayouts.mul(A,B)
+        end            
     end
     for Struc in (:AbstractTriangular, :Diagonal)
         ret = quote

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -196,6 +196,11 @@ macro layoutmul(Typ)
 
         Base.:*(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
         Base.:*(A::$Typ, B::LinearAlgebra.AbstractQ) = ArrayLayouts.mul(A,B)
+        # disambiguation
+        Base.:*(A::Union{LinearAlgebra.HessenbergQ, LinearAlgebra.QRCompactWYQ, LinearAlgebra.QRPackedQ}, B::$Typ) =
+            ArrayLayouts.mul(A,B)
+        Base.:*(A::$Typ, B::Union{LinearAlgebra.HessenbergQ, LinearAlgebra.QRCompactWYQ, LinearAlgebra.QRPackedQ}) =
+            ArrayLayouts.mul(A,B)
         if isdefined(LinearAlgebra, :AdjointQ)
             Base.:*(A::LinearAlgebra.AdjointQ, B::$Typ) = ArrayLayouts.mul(A,B)
             Base.:*(A::$Typ, B::LinearAlgebra.AdjointQ) = ArrayLayouts.mul(A,B)

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -132,6 +132,7 @@ macro veclayoutmul(Typ)
         (*)(A::LinearAlgebra.TransposeAbsVec{T,<:$Typ{T}}, B::AbstractVector{T}) where T<:Real = ArrayLayouts.mul(A,B)
 
         (*)(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::$Typ, B::LinearAlgebra.LQPackedQ) = ArrayLayouts.mul(A,B)
     end
     for Struc in (:AbstractTriangular, :Diagonal)
         ret = quote
@@ -196,15 +197,6 @@ macro layoutmul(Typ)
 
         (*)(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
         (*)(A::$Typ, B::LinearAlgebra.AbstractQ) = ArrayLayouts.mul(A,B)
-        # disambiguation
-        (*)(A::Union{LinearAlgebra.HessenbergQ, LinearAlgebra.QRCompactWYQ, LinearAlgebra.QRPackedQ}, B::$Typ) =
-            ArrayLayouts.mul(A,B)
-        (*)(A::$Typ, B::Union{LinearAlgebra.HessenbergQ, LinearAlgebra.QRCompactWYQ, LinearAlgebra.QRPackedQ}) =
-            ArrayLayouts.mul(A,B)
-        if isdefined(LinearAlgebra, :AdjointQ)
-            (*)(A::LinearAlgebra.AdjointQ, B::$Typ) = ArrayLayouts.mul(A,B)
-            (*)(A::$Typ, B::LinearAlgebra.AdjointQ) = ArrayLayouts.mul(A,B)
-        end            
     end
     for Struc in (:AbstractTriangular, :Diagonal)
         ret = quote

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -121,23 +121,23 @@ broadcastable(M::Mul) = M
 
 macro veclayoutmul(Typ)
     ret = quote
-        Base.:*(A::AbstractMatrix, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::Adjoint{<:Any,<:AbstractMatrix{T}}, B::$Typ{S}) where {T,S} = ArrayLayouts.mul(A,B)
-        Base.:*(A::Transpose{<:Any,<:AbstractMatrix{T}}, B::$Typ{S}) where {T,S} = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.AdjointAbsVec, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.TransposeAbsVec, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.AdjointAbsVec{<:Number}, B::$Typ{<:Number}) = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.TransposeAbsVec{T}, B::$Typ{T}) where T<:Real = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.TransposeAbsVec{T,<:$Typ{T}}, B::$Typ{T}) where T<:Real = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.TransposeAbsVec{T,<:$Typ{T}}, B::AbstractVector{T}) where T<:Real = ArrayLayouts.mul(A,B)
+        (*)(A::AbstractMatrix, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::Adjoint{<:Any,<:AbstractMatrix{T}}, B::$Typ{S}) where {T,S} = ArrayLayouts.mul(A,B)
+        (*)(A::Transpose{<:Any,<:AbstractMatrix{T}}, B::$Typ{S}) where {T,S} = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.AdjointAbsVec, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.TransposeAbsVec, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.AdjointAbsVec{<:Number}, B::$Typ{<:Number}) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.TransposeAbsVec{T}, B::$Typ{T}) where T<:Real = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.TransposeAbsVec{T,<:$Typ{T}}, B::$Typ{T}) where T<:Real = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.TransposeAbsVec{T,<:$Typ{T}}, B::AbstractVector{T}) where T<:Real = ArrayLayouts.mul(A,B)
 
-        Base.:*(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
     end
     for Struc in (:AbstractTriangular, :Diagonal)
         ret = quote
             $ret
 
-            Base.:*(A::LinearAlgebra.$Struc, B::$Typ) = ArrayLayouts.mul(A,B)
+            (*)(A::LinearAlgebra.$Struc, B::$Typ) = ArrayLayouts.mul(A,B)
         end
     end
     for Mod in (:AdjointAbsVec, :TransposeAbsVec)
@@ -147,14 +147,14 @@ macro veclayoutmul(Typ)
             LinearAlgebra.mul!(dest::AbstractVector, A::$Mod{<:Any,<:$Typ}, b::AbstractVector) =
                 ArrayLayouts.mul!(dest,A,b)
 
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::ArrayLayouts.LayoutMatrix) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::AbstractMatrix) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::AbstractVector) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Number,<:$Typ}, B::AbstractVector{<:Number}) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::$Typ) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Number,<:$Typ}, B::$Typ{<:Number}) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::Diagonal) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::LinearAlgebra.AbstractTriangular) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::ArrayLayouts.LayoutMatrix) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::AbstractMatrix) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::AbstractVector) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Number,<:$Typ}, B::AbstractVector{<:Number}) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::$Typ) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Number,<:$Typ}, B::$Typ{<:Number}) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::Diagonal) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::LinearAlgebra.AbstractTriangular) = ArrayLayouts.mul(A,B)
         end
     end
 
@@ -183,35 +183,35 @@ macro layoutmul(Typ)
         LinearAlgebra.mul!(dest::AbstractMatrix, A::$Typ, B::$Typ, α::Number, β::Number) =
             ArrayLayouts.mul!(dest,A,B,α,β)
 
-        Base.:*(A::$Typ, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::$Typ, B::AbstractMatrix) = ArrayLayouts.mul(A,B)
-        Base.:*(A::$Typ, B::AbstractVector) = ArrayLayouts.mul(A,B)
-        Base.:*(A::$Typ, B::ArrayLayouts.LayoutVector) = ArrayLayouts.mul(A,B)
-        Base.:*(A::AbstractMatrix, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.AdjointAbsVec, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.TransposeAbsVec, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.AdjointAbsVec{<:Any,<:Zeros{<:Any,1}}, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.TransposeAbsVec{<:Any,<:Zeros{<:Any,1}}, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::LinearAlgebra.Transpose{T,<:$Typ}, B::Zeros{T,1}) where T<:Real = ArrayLayouts.mul(A,B)
+        (*)(A::$Typ, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::$Typ, B::AbstractMatrix) = ArrayLayouts.mul(A,B)
+        (*)(A::$Typ, B::AbstractVector) = ArrayLayouts.mul(A,B)
+        (*)(A::$Typ, B::ArrayLayouts.LayoutVector) = ArrayLayouts.mul(A,B)
+        (*)(A::AbstractMatrix, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.AdjointAbsVec, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.TransposeAbsVec, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.AdjointAbsVec{<:Any,<:Zeros{<:Any,1}}, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.TransposeAbsVec{<:Any,<:Zeros{<:Any,1}}, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.Transpose{T,<:$Typ}, B::Zeros{T,1}) where T<:Real = ArrayLayouts.mul(A,B)
 
-        Base.:*(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
-        Base.:*(A::$Typ, B::LinearAlgebra.AbstractQ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.AbstractQ, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::$Typ, B::LinearAlgebra.AbstractQ) = ArrayLayouts.mul(A,B)
         # disambiguation
-        Base.:*(A::Union{LinearAlgebra.HessenbergQ, LinearAlgebra.QRCompactWYQ, LinearAlgebra.QRPackedQ}, B::$Typ) =
+        (*)(A::Union{LinearAlgebra.HessenbergQ, LinearAlgebra.QRCompactWYQ, LinearAlgebra.QRPackedQ}, B::$Typ) =
             ArrayLayouts.mul(A,B)
-        Base.:*(A::$Typ, B::Union{LinearAlgebra.HessenbergQ, LinearAlgebra.QRCompactWYQ, LinearAlgebra.QRPackedQ}) =
+        (*)(A::$Typ, B::Union{LinearAlgebra.HessenbergQ, LinearAlgebra.QRCompactWYQ, LinearAlgebra.QRPackedQ}) =
             ArrayLayouts.mul(A,B)
         if isdefined(LinearAlgebra, :AdjointQ)
-            Base.:*(A::LinearAlgebra.AdjointQ, B::$Typ) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Typ, B::LinearAlgebra.AdjointQ) = ArrayLayouts.mul(A,B)
+            (*)(A::LinearAlgebra.AdjointQ, B::$Typ) = ArrayLayouts.mul(A,B)
+            (*)(A::$Typ, B::LinearAlgebra.AdjointQ) = ArrayLayouts.mul(A,B)
         end            
     end
     for Struc in (:AbstractTriangular, :Diagonal)
         ret = quote
             $ret
 
-            Base.:*(A::LinearAlgebra.$Struc, B::$Typ) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Typ, B::LinearAlgebra.$Struc) = ArrayLayouts.mul(A,B)
+            (*)(A::LinearAlgebra.$Struc, B::$Typ) = ArrayLayouts.mul(A,B)
+            (*)(A::$Typ, B::LinearAlgebra.$Struc) = ArrayLayouts.mul(A,B)
         end
     end
     for Mod in (:Adjoint, :Transpose, :Symmetric, :Hermitian)
@@ -237,23 +237,23 @@ macro layoutmul(Typ)
             LinearAlgebra.mul!(dest::AbstractMatrix, A::$Mod{<:Any,<:$Typ}, B::$Mod{<:Any,<:$Typ}, α::Number, β::Number) =
                 ArrayLayouts.mul!(dest,A,B,α,β)
 
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::AbstractMatrix) = ArrayLayouts.mul(A,B)
-            Base.:*(A::AbstractMatrix, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
-            Base.:*(A::LinearAlgebra.AdjointAbsVec, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
-            Base.:*(A::LinearAlgebra.TransposeAbsVec, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::AbstractVector) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::ArrayLayouts.LayoutVector) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::Zeros{<:Any,1}) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::AbstractMatrix) = ArrayLayouts.mul(A,B)
+            (*)(A::AbstractMatrix, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
+            (*)(A::LinearAlgebra.AdjointAbsVec, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
+            (*)(A::LinearAlgebra.TransposeAbsVec, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::AbstractVector) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::ArrayLayouts.LayoutVector) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::Zeros{<:Any,1}) = ArrayLayouts.mul(A,B)
 
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::$Typ) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Typ, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::$Typ) = ArrayLayouts.mul(A,B)
+            (*)(A::$Typ, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
 
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::Diagonal) = ArrayLayouts.mul(A,B)
-            Base.:*(A::Diagonal, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::Diagonal) = ArrayLayouts.mul(A,B)
+            (*)(A::Diagonal, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
 
-            Base.:*(A::LinearAlgebra.AbstractTriangular, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
-            Base.:*(A::$Mod{<:Any,<:$Typ}, B::LinearAlgebra.AbstractTriangular) = ArrayLayouts.mul(A,B)
+            (*)(A::LinearAlgebra.AbstractTriangular, B::$Mod{<:Any,<:$Typ}) = ArrayLayouts.mul(A,B)
+            (*)(A::$Mod{<:Any,<:$Typ}, B::LinearAlgebra.AbstractTriangular) = ArrayLayouts.mul(A,B)
         end
     end
 
@@ -282,7 +282,7 @@ struct Dot{StyleA,StyleB,ATyp,BTyp}
 end
 
 @inline Dot(A::ATyp,B::BTyp) where {ATyp,BTyp} = Dot{typeof(MemoryLayout(ATyp)), typeof(MemoryLayout(BTyp)), ATyp, BTyp}(A, B)
-@inline copy(d::Dot) = Base.invoke(LinearAlgebra.dot, Tuple{AbstractArray,AbstractArray}, d.A, d.B)
+@inline copy(d::Dot) = invoke(LinearAlgebra.dot, Tuple{AbstractArray,AbstractArray}, d.A, d.B)
 @inline materialize(d::Dot) = copy(instantiate(d))
 @inline Dot(M::Mul{<:DualLayout,<:Any,<:AbstractMatrix,<:AbstractVector}) = Dot(M.A', M.B)
 @inline mulreduce(M::Mul{<:DualLayout,<:Any,<:AbstractMatrix,<:AbstractVector}) = Dot(M)
@@ -312,7 +312,7 @@ LinearAlgebra.dot(x::AbstractVector, A::Symmetric{<:Real,<:LayoutMatrix}, y::Abs
 
 
 # allow overloading for infinite or lazy case
-@inline _power_by_squaring(_, _, A, p) = Base.invoke(Base.power_by_squaring, Tuple{AbstractMatrix,Integer}, A, p)
+@inline _power_by_squaring(_, _, A, p) = invoke(Base.power_by_squaring, Tuple{AbstractMatrix,Integer}, A, p)
 # TODO: Remove unnecessary _apply
 _apply(_, _, op, Λ::UniformScaling, A::AbstractMatrix) = op(Diagonal(Fill(Λ.λ,(axes(A,1),))), A)
 _apply(_, _, op, A::AbstractMatrix, Λ::UniformScaling) = op(A, Diagonal(Fill(Λ.λ,(axes(A,1),))))

--- a/src/muladd.jl
+++ b/src/muladd.jl
@@ -221,7 +221,7 @@ function _default_blasmul!(::IndexCartesian, α, A::AbstractMatrix, B::AbstractV
 end
 
 default_blasmul!(α, A::AbstractMatrix, B::AbstractVector, β, C::AbstractVector) =
-    _default_blasmul!(Base.IndexStyle(typeof(A)), α, A, B, β, C)
+    _default_blasmul!(IndexStyle(typeof(A)), α, A, B, β, C)
 
 function materialize!(M::MatMulMatAdd)
     α, A, B, β, C = M.α, M.A, M.B, M.β, M.C

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -1,5 +1,5 @@
 using ArrayLayouts, LinearAlgebra, FillArrays, Base64, Test
-import ArrayLayouts: sub_materialize, MemoryLayout, ColumnNorm, RowMaximum, CRowMaximum
+using ArrayLayouts: sub_materialize, MemoryLayout, ColumnNorm, RowMaximum, CRowMaximum
 
 
 struct MyMatrix <: LayoutMatrix{Float64}

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -93,7 +93,7 @@ MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
             @test_throws ErrorException qr!(A)
             @test lu!(copy(A)).factors ≈ lu(A.A).factors
             b = randn(5)
-            @test all(A \ b .≡ A.A \ b .≡ A.A \ MyVector(b))
+            @test all(A \ b .≡ A.A \ b .≡ A.A \ MyVector(b) .≡ ldiv!(lu(A.A)), copy(MyVector(b)))
             @test all(lu(A).L .≡ lu(A.A).L)
             @test all(lu(A).U .≡ lu(A.A).U)
             @test lu(A).p == lu(A.A).p
@@ -107,7 +107,7 @@ MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
             @test cholesky(S, CRowMaximum()).U ≈ cholesky(Matrix(S), CRowMaximum()).U
             @test cholesky(S) \ b ≈ cholesky(Matrix(S)) \ b ≈ cholesky(Matrix(S)) \ MyVector(b)
             @test cholesky(S, CRowMaximum()) \ b ≈ cholesky(Matrix(S), CRowMaximum()) \ b
-            @test cholesky(S, CRowMaximum()) \ b ≈ cholesky(Matrix(S), CRowMaximum()) \ MyVector(b)
+            @test cholesky(S, CRowMaximum()) \ b ≈ ldiv!(cholesky(Matrix(S), CRowMaximum()), copy(MyVector(b)))
 
             S = Symmetric(MyMatrix(reshape(inv.(1:25),5,5) + 10I),:L)
             @test cholesky(S).U ≈ @inferred(cholesky!(deepcopy(S))).U

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -93,7 +93,7 @@ MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
             @test_throws ErrorException qr!(A)
             @test lu!(copy(A)).factors ≈ lu(A.A).factors
             b = randn(5)
-            @test all(A \ b .≡ A.A \ b .≡ A.A \ MyVector(b) .≡ ldiv!(lu(A.A)), copy(MyVector(b)))
+            @test all(A \ b .≡ A.A \ b .≡ A.A \ MyVector(b) .≡ ldiv!(lu(A.A), copy(MyVector(b))))
             @test all(lu(A).L .≡ lu(A.A).L)
             @test all(lu(A).U .≡ lu(A.A).U)
             @test lu(A).p == lu(A.A).p

--- a/test/test_muladd.jl
+++ b/test/test_muladd.jl
@@ -1,5 +1,5 @@
 using ArrayLayouts, FillArrays, Random, StableRNGs, LinearAlgebra, Test
-import ArrayLayouts: DenseColumnMajor, AbstractStridedLayout, AbstractColumnMajor, DiagonalLayout, mul, Mul, zero!
+using ArrayLayouts: DenseColumnMajor, AbstractStridedLayout, AbstractColumnMajor, DiagonalLayout, mul, Mul, zero!
 
 Random.seed!(0)
 @testset "Multiplication" begin


### PR DESCRIPTION
~~This is a companion PR to https://github.com/JuliaLang/julia/pull/46196, in case that one gets accepted. This will fail on nightly before that LinearAlgebra PR gets merged.~~ I have removed the `AdjointQ` stuff and left the pure code clean-up part. I carefully reviewed which functions are actually overloaded (hence need to be `import`ed)  and which ones are only `use`d. I also removed obsolete package specifiers and added a few factorization `ldiv!`s to make the package proof for some work in `LinearAlgebra.jl`.