### PR TITLE
transpose in copy(::Rmul) for Vector{<:Number}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.8.18"
+version = "0.8.19"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -17,7 +17,9 @@ end
 
 copy(M::Lmul{<:DiagonalLayout,<:DiagonalLayout}) = diagonal(diagonaldata(M.A) .* diagonaldata(M.B))
 copy(M::Lmul{<:DiagonalLayout}) = diagonaldata(M.A) .* M.B
-copy(M::Rmul{<:Any,<:DiagonalLayout}) = M.A .* permutedims(diagonaldata(M.B))
+_permutedims(A::AbstractArray{<:Number}) = transpose(A)
+_permutedims(A::AbstractArray) = permutedims(A)
+copy(M::Rmul{<:Any,<:DiagonalLayout}) = M.A .* _permutedims(diagonaldata(M.B))
 
 
 


### PR DESCRIPTION
This avoids an explicit copy for vectors of numbers, which improves performance.