### PR TITLE
Improve cache localization in default_blasmul

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/muladd.jl
+++ b/src/muladd.jl
@@ -182,7 +182,7 @@ function default_blasmul!(α, A::AbstractMatrix, B::AbstractMatrix, β, C::Abstr
             _default_blasmul_loop!(α, A, B, β, C, k, j)
         end
     else
-        @inbounds for k in colsupport(A), j in rowsupport(B,rowsupport(A,k))
+        for k in colsupport(A), j in rowsupport(B,rowsupport(A,k))
             _default_blasmul_loop!(α, A, B, β, C, k, j)
         end
     end


### PR DESCRIPTION
The order of the loop was cache unfriendly, but it was written this way because the range of the row variable may depend on the column one. However, we may carry out a quick check to ascertain whether the row range is actually independent of the column one, in which case we may switch them and loop in a cache-friendly manner. This branching improves performance in banded*dense matmul. The original behavior is retained in the fallback branch.

```julia
julia> B = brand(4000, 4000, 5, 5);

julia> X = rand(4000, 4000);

julia> @btime $B * $X;
  977.570 ms (2 allocations: 122.07 MiB) # master
  518.942 ms (2 allocations: 122.07 MiB) # PR
```