### PR TITLE
5-arg mul! for matrix*vector

### DIFF
--- a/src/mul.jl
+++ b/src/mul.jl
@@ -190,6 +190,8 @@ macro layoutmul(Typ)
     ret = quote
         LinearAlgebra.mul!(dest::AbstractVector, A::$Typ, b::AbstractVector) =
             ArrayLayouts.mul!(dest,A,b)
+        LinearAlgebra.mul!(dest::AbstractVector, A::$Typ, b::AbstractVector, α::Number, β::Number) =
+            ArrayLayouts.mul!(dest,A,b,α,β)
 
         LinearAlgebra.mul!(dest::AbstractMatrix, A::$Typ, B::AbstractMatrix) =
             ArrayLayouts.mul!(dest,A,B)


### PR DESCRIPTION
This method seems to have been missed, and adding this provides a significant performance boost in matrix*vector operations:

```julia
julia> B = brand(4000, 4000, 5, 5);

julia> v = rand(size(B,2));

julia> @btime mul!($(copy(v)), $B, $v, 1.0, 1.0);
  40.232 ms (0 allocations: 0 bytes) # master
  22.385 μs (0 allocations: 0 bytes) # PR
```