### PR TITLE
Improve error message if scalarone hits bottom type

### DIFF
--- a/src/muladd.jl
+++ b/src/muladd.jl
@@ -366,9 +366,9 @@ end
 BroadcastStyle(::Type{<:MulAdd}) = ApplyBroadcastStyle()
 
 scalarone(::Type{T}) where T = one(T)
-scalarone(::Type{<:AbstractArray{T}}) where T = scalarone(T)
+scalarone(::Type{A}) where {A<:AbstractArray} = scalarone(eltype(A))
 scalarzero(::Type{T}) where T = zero(T)
-scalarzero(::Type{<:AbstractArray{T}}) where T = scalarzero(T)
+scalarzero(::Type{A}) where {A<:AbstractArray} = scalarzero(eltype(A))
 
 fillzeros(::Type{T}, ax) where T<:Number = Zeros{T}(ax)
 mulzeros(::Type{T}, M) where T<:Number = fillzeros(T, axes(M))


### PR DESCRIPTION
This is a fringe case, and it's only hit for incorrect input types. Nonetheless, it's better to be less cryptic in the error message here.

```julia
julia> A = BandedMatrix(0=>fill(Day(2), 4))
4×4 BandedMatrix{Day} with bandwidths (0, 0):
 2 days    ⋅       ⋅       ⋅   
   ⋅     2 days    ⋅       ⋅   
   ⋅       ⋅     2 days    ⋅   
   ⋅       ⋅       ⋅     2 days

julia> B = BandedMatrix(0=>fill(today(), 4), 1=>fill(today(), 3))
4×4 BandedMatrix{Date} with bandwidths (0, 1):
 2023-05-02  2023-05-02    ⋅                   ⋅   
   ⋅                 2023-05-02  2023-05-02    ⋅   
   ⋅                   ⋅                 2023-05-02  2023-05-02
   ⋅                   ⋅                   ⋅                 2023-05-02

julia> A * B
ERROR: UndefVarError: `T` not defined
Stacktrace:
 [1] scalarone(#unused#::Core.TypeofBottom)
[...]
```
This PR
```julia
julia> A * B
ERROR: ArgumentError: Union{} does not have elements
Stacktrace:
 [1] eltype(#unused#::Type{Union{}})
   @ Base ./abstractarray.jl:234
 [2] scalarone(#unused#::Core.TypeofBottom)
   @ ArrayLayouts ~/Dropbox/JuliaPackages/ArrayLayouts.jl/src/muladd.jl:369
[...]
```
The improvement is that we can see that the issue is with `eltype(Union{})`