### PR TITLE
Help disambiguation with special matrix types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"


### PR DESCRIPTION
This came up in https://github.com/JuliaLang/julia/pull/43972. Generally speaking, there are (classes of) matrix types that dominates the respective other factor (in terms of whose multiplication code should be applied). One such example is LayoutMatrix, obviously, other examples are LinearAlgebra's AbstractTriangular and "banded" matrices. For the latter, this PR adds the required disambiguating `mul!` methods.