### PR TITLE
convert RangeCumsum's parent type

### DIFF
--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -9,7 +9,7 @@ using Base: AbstractCartesianIndex, OneTo, RangeIndex, ReinterpretArray, Reshape
 
 import Base: axes, size, length, eltype, ndims, first, last, diff, isempty, union, sort!,
                 ==, *, +, -, /, \, copy, copyto!, similar, getproperty, getindex, strides,
-                reverse, unsafe_convert
+                reverse, unsafe_convert, convert
 
 using Base.Broadcast: Broadcasted
 

--- a/src/cumsum.jl
+++ b/src/cumsum.jl
@@ -35,3 +35,5 @@ union(a::RangeCumsum{<:Any,<:OneTo}, b::RangeCumsum{<:Any,<:OneTo}) =
     RangeCumsum(OneTo(max(last(a.range), last(b.range))))
 
 sort!(a::RangeCumsum{<:Any,<:AbstractUnitRange}) = a
+
+convert(::Type{RangeCumsum{T,R}}, r::RangeCumsum) where {T,R} = RangeCumsum{T,R}(convert(R, r.range))

--- a/test/test_cumsum.jl
+++ b/test/test_cumsum.jl
@@ -14,4 +14,8 @@ using ArrayLayouts, Test
     a,b = RangeCumsum(Base.OneTo(5)), RangeCumsum(Base.OneTo(6))
     @test union(a,b) ≡ union(b,a) ≡ b
     @test sort!(a) ≡ a
+
+    a = RangeCumsum(Base.OneTo(3))
+    b = RangeCumsum(1:3)
+    @test oftype(a, b) === a
 end


### PR DESCRIPTION
This lets one convert the types of `RangeCumsum` objects, which may be helpful for type-stability downstream.

```julia
julia> oftype(RangeCumsum(1:3), RangeCumsum(Base.OneTo(3)))
3-element RangeCumsum{Int64, UnitRange{Int64}}:
 1
 3
 6
```