### PR TITLE
Add `sub_materialize_axes` to dispatch on axes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.0.7"
+version = "1.0.8"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -109,7 +109,9 @@ include("diagonal.jl")
 include("triangular.jl")
 include("factorizations.jl")
 
-@inline sub_materialize(_, V, _) = Array(V)
+# Extend this function if you're only looking to dispatch on the axes
+@inline sub_materialize_axes(V, _) = Array(V)
+@inline sub_materialize(_, V, ax) = sub_materialize_axes(V, ax)
 @inline sub_materialize(L, V) = sub_materialize(L, V, axes(V))
 @inline sub_materialize(V::SubArray) = sub_materialize(MemoryLayout(V), V)
 @inline sub_materialize(V) = V # Anything not a SubArray is already materialized


### PR DESCRIPTION
Extending this function avoids ambiguities in the first argument (the `MemoryLayout`), in case one package defines 
```julia
sub_materialize(::Any, V, ax::Tuple{axtypes})
```
and another defines 
```julia
sub_materialize(::SpecificLayout, V, ax)
```

Ideally, this would be done as
```julia
sub_materialize(L, V, ax) = sub_materialize(UnknownLayout(), V, ax)
sub_materialize(::UnknownLayout, V, ax) = Array(V)
```
and the first method above would be rewritten as
```julia
sub_materialize(::UnknownLayout, V, ax::Tuple{axtypes})
```
but this is breaking at present, as that's not how it's defined at present.  Introducing a separate function is a workaround, but this makes the intent clear.