### PR TITLE
Prepare for removal of `FillArrays._copy_oftype`

### DIFF
--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -25,7 +25,7 @@ using LinearAlgebra.BLAS: BlasFloat, BlasReal, BlasComplex
 
 AdjointQtype{T} = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ{T} : Adjoint{T,<:AbstractQ}
 
-using FillArrays: AbstractFill, getindex_value, axes_print_matrix_row, _copy_oftype
+using FillArrays: AbstractFill, getindex_value, axes_print_matrix_row
 
 using Base: require_one_based_indexing
 
@@ -52,6 +52,12 @@ else
     const CNoPivot = NoPivot
 end
 
+if isdefined(FillArrays, :_copy_oftype)
+    const _copy_oftype = FillArrays._copy_oftype
+else
+    _copy_oftype(A::AbstractArray, ::Type{S}) where {S} = eltype(A) == S ? copy(A) : AbstractArray{S}(A)
+    _copy_oftype(A::AbstractRange, ::Type{S}) where {S} = eltype(A) == S ? copy(A) : map(S, A)
+end
 
 struct ApplyBroadcastStyle <: BroadcastStyle end
 @inline function copyto!(dest::AbstractArray, bc::Broadcasted{ApplyBroadcastStyle})


### PR DESCRIPTION
https://github.com/JuliaArrays/FillArrays.jl/pull/273 plans to remove the internal function `FillArrays._copy_oftype` since it is not used anymore in FillArrays. It seems ArrayLayouts imports this internal function and hence will be broken if it is not available anymore. This PR fixes the problem by defining the helper function in ArrayLayouts itself if `FillArrays._copy_oftype` is not available.

Alternatively, a slightly simpler approach would be to unconditionally define `_copy_oftype` in ArrayLayouts - at the cost of an additional method if `FillArrays._copy_oftype` exists.

When this PR is merged, we can rerun the downstream tests in https://github.com/JuliaArrays/FillArrays.jl/pull/273 to ensure that the ArrayLayouts master is not broken by the FillArrays PR.

cc: @jishnub 