### PR TITLE
Accelerate recursive `Mul`

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -34,6 +34,7 @@ jobs:
           - {repo: BandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: InfiniteArrays.jl, group: JuliaArrays}
+          - {repo: LazyArrays.jl, group: JuliaArrays}
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 deps/deps.jl
 Manifest.toml
 .DS_Store
+statprof/*

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -9,7 +9,7 @@ using Base: AbstractCartesianIndex, OneTo, RangeIndex, ReinterpretArray, Reshape
 
 import Base: axes, size, length, eltype, ndims, first, last, diff, isempty, union, sort!,
                 ==, *, +, -, /, \, copy, copyto!, similar, getproperty, getindex, strides,
-                reverse, unsafe_convert, convert, view
+                reverse, unsafe_convert, convert, view, maybeview
 
 using Base.Broadcast: Broadcasted
 

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -154,6 +154,7 @@ macro _layoutgetindex(Typ)
         @inline getindex(A::$Typ, kr::AbstractVector, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
         @inline getindex(A::$Typ, kr::Integer, jr::Colon) = ArrayLayouts.layout_getindex(A, kr, jr)
         @inline getindex(A::$Typ, kr::Integer, jr::AbstractVector) = ArrayLayouts.layout_getindex(A, kr, jr)
+        @inline getindex(A::$Typ, kr::AbstractVector, jr::Integer) = ArrayLayouts.layout_getindex(A, kr, jr)
     end)
 end
 

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -46,7 +46,7 @@ end
 function _getindex(::Type{Tuple{AA,BB}}, M::Mul, (k, j)::Tuple{AA,BB}) where {AA,BB}
     A,B = M.A,M.B
     I = rowsupport(A,k) ∩ colsupport(B,j)
-    dot(A[k,I], B[I,j])
+    A[k,I]'*B[I,j]
 end
 
 # linear indexing

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -46,7 +46,7 @@ end
 function _getindex(::Type{Tuple{AA,BB}}, M::Mul{SA,SB}, (k, j)::Tuple{AA,BB}) where {AA,BB,SA,SB}
     A,B = M.A,M.B
     I = rowsupport(A,k) ∩ colsupport(B,j)
-    maybeview(A,k,I)'*maybeview(B,I,j)
+    transpose(maybeview(A,k,I))*maybeview(B,I,j)
 end
 
 maybeview(A::AbstractArray, k...) = maybeview_layout(MemoryLayout(A), k...)

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -45,11 +45,8 @@ end
 
 function _getindex(::Type{Tuple{AA,BB}}, M::Mul, (k, j)::Tuple{AA,BB}) where {AA,BB}
     A,B = M.A,M.B
-    ret = zeroeltype(M)
-    @inbounds for ℓ in (rowsupport(A,k) ∩ colsupport(B,j))
-        ret += A[k,ℓ] * B[ℓ,j]
-    end
-    ret
+    I = rowsupport(A,k) ∩ colsupport(B,j)
+    dot(A[k,I], B[I,j])
 end
 
 # linear indexing

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -43,11 +43,14 @@ function _getindex(::Type{Tuple{AA}}, M::Mul, (k,)::Tuple{AA}) where AA
     ret
 end
 
-function _getindex(::Type{Tuple{AA,BB}}, M::Mul, (k, j)::Tuple{AA,BB}) where {AA,BB}
+function _getindex(::Type{Tuple{AA,BB}}, M::Mul{SA,SB}, (k, j)::Tuple{AA,BB}) where {AA,BB,SA,SB}
     A,B = M.A,M.B
     I = rowsupport(A,k) ∩ colsupport(B,j)
-    A[k,I]'*B[I,j]
+    maybeview(A,k,I)'*maybeview(B,I,j)
 end
+
+maybeview(A::AbstractArray, k...) = maybeview_layout(MemoryLayout(A), k...)
+maybeview_layout(::MemoryLayout, A, k...) = view(A, k...)
 
 # linear indexing
 _getindex(::Type{NTuple{2,Int}}, M, k::Tuple{Int}) = M[Base._ind2sub(axes(M), k...)...]


### PR DESCRIPTION
This change only takes effect after https://github.com/JuliaArrays/LazyArrays.jl/pull/261

```julia
using LazyArrays

A = ApplyArray(*, [ones(10,10) for _ in 1:10]...);
@time for m in 1:10, n in 1:10
    A[m,n]
end

B = ones(10,10)
for k in 1:5
    B = ApplyArray(*, B, B)
end
@time for m in 1:10, n in 1:10
    B[m,n]
end

C = ones(10,10)
M = Mul(C, C)
@time for m in 1:10, n in 1:10
    M[m,n]
end
```

Before: exponential in depth
```
256.268356 seconds (451.16 M allocations: 13.413 GiB, 1.39% gc time)
0.615169 seconds (3.37 M allocations: 105.647 MiB, 4.57% gc time)
0.000029 seconds (100 allocations: 1.562 KiB)
```

After: linear in operations
```
0.003850 seconds (4.50 k allocations: 1.401 MiB)
0.059771 seconds (27.50 k allocations: 6.798 MiB)
0.000078 seconds (300 allocations: 29.688 KiB)
```