### PR TITLE
Fix ambiguity issue with `rdiv!`

### DIFF
--- a/src/ldiv.jl
+++ b/src/ldiv.jl
@@ -156,6 +156,8 @@ macro _layoutldiv(Typ)
 
         LinearAlgebra.rdiv!(A::AbstractMatrix, B::$Typ; kwds...) = ArrayLayouts.rdiv!(A,B; kwds...)
 
+        # Fix ambiguity issue
+        LinearAlgebra.rdiv!(A::StridedMatrix, B::$Typ; kwds...) = ArrayLayouts.rdiv!(A,B; kwds...)
 
         (\)(A::$Typ, x::AbstractVector; kwds...) = ArrayLayouts.ldiv(A,x; kwds...)
         (\)(A::$Typ, x::AbstractMatrix; kwds...) = ArrayLayouts.ldiv(A,x; kwds...)


### PR DESCRIPTION
In a downstream PR I encountered an ambiguity issue caused by ArrayLayouts: https://github.com/JuliaStats/PDMats.jl/actions/runs/5720019750/job/15499152626?pr=175#step:6:201 This PR implements the suggested solution (adding a method for `StridedMatrix`).