### PR TITLE
WIP: make FillArrays.jl a weakdep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,18 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[weakdeps]
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+
+[extensions]
+ArrayLayoutsFillArraysExt = "FillArrays"
 
 [compat]
 FillArrays = "1.2.1"
@@ -14,9 +20,10 @@ julia = "1.6"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Base64", "Random", "StableRNGs", "Test"]
+test = ["Base64", "FillArrays", "Random", "StableRNGs", "Test"]

--- a/ext/ArrayLayoutsFillArraysExt.jl
+++ b/ext/ArrayLayoutsFillArraysExt.jl
@@ -1,0 +1,113 @@
+module ArrayLayoutsFillArraysExt
+
+using FillArrays
+using FillArrays: AbstractFill, getindex_value
+
+using ArrayLayouts
+using ArrayLayouts: OnesLayout, Mul, MulAdd
+import ArrayLayouts: MemoryLayout, _copyto!, sub_materialize, diagonaldata
+export layoutfillmul, mulzeros
+
+import Base: copy, *
+import Base.Broadcast: materialize!
+import LinearAlgebra
+using LinearAlgebra: Adjoint, Transpose, Symmetric, Hermitian, Diagonal,
+    AdjointAbsVec, TransposeAbsVec, UniformScaling
+
+macro layoutfillmul(Typ)
+    ret = quote
+        (*)(A::LinearAlgebra.AdjointAbsVec{<:Any,<:Zeros{<:Any,1}}, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.TransposeAbsVec{<:Any,<:Zeros{<:Any,1}}, B::$Typ) = ArrayLayouts.mul(A,B)
+        (*)(A::LinearAlgebra.Transpose{T,<:$Typ}, B::Zeros{T,1}) where T<:Real = ArrayLayouts.mul(A,B)
+    end
+    for Mod in (:Adjoint, :Transpose, :Symmetric, :Hermitian)
+        ret = quote
+            $ret
+
+            (*)(A::$Mod{<:Any,<:$Typ}, B::Zeros{<:Any,1}) = ArrayLayouts.mul(A,B)
+        end
+    end
+    esc(ret)
+end
+
+@layoutfillmul LayoutMatrix
+
+*(a::Zeros{<:Any,2}, b::LayoutMatrix) = FillArrays.mult_zeros(a, b)
+*(a::LayoutMatrix, b::Zeros{<:Any,2}) = FillArrays.mult_zeros(a, b)
+*(a::LayoutMatrix, b::Zeros{<:Any,1}) = FillArrays.mult_zeros(a, b)
+*(a::Transpose{T, <:LayoutMatrix{T}} where T, b::Zeros{<:Any, 2}) = FillArrays.mult_zeros(a, b)
+*(a::Adjoint{T, <:LayoutMatrix{T}} where T, b::Zeros{<:Any, 2}) = FillArrays.mult_zeros(a, b)
+*(A::Adjoint{<:Any, <:Zeros{<:Any,1}}, B::Diagonal{<:Any,<:LayoutVector}) = (B' * A')'
+*(A::Transpose{<:Any, <:Zeros{<:Any,1}}, B::Diagonal{<:Any,<:LayoutVector}) = transpose(transpose(B) * transpose(A))
+
+# equivalent to rescaling
+function materialize!(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout}})
+    M.B .= getindex_value(M.A.diag) .* M.B
+    M.B
+end
+# equivalent to rescaling
+function materialize!(M::Rmul{<:Any,<:DiagonalLayout{<:AbstractFillLayout}})
+    M.A .= M.A .* getindex_value(M.B.diag)
+    M.A
+end
+
+copy(M::Ldiv{<:DiagonalLayout{<:AbstractFillLayout}}) = inv(getindex_value(M.A.diag)) .* M.B
+copy(M::Ldiv{<:DiagonalLayout{<:AbstractFillLayout},<:DiagonalLayout}) = diagonal(inv(getindex_value(M.A.diag)) .* M.B.diag)
+
+copy(M::Rdiv{<:Any,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A .* inv(getindex_value(M.B.diag))
+copy(M::Rdiv{<:DiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = diagonal(M.A.diag .* inv(getindex_value(M.B.diag)))
+
+copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout}}) = getindex_value(diagonaldata(M.A)) * M.B
+copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:DiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
+copy(M::Rmul{<:Any,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
+copy(M::Rmul{<:DualLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
+
+copy(M::Rmul{<:BidiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
+copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:BidiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
+copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
+copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:TridiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
+copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
+copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:SymTridiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
+
+MemoryLayout(::Type{<:AbstractFill}) = FillLayout()
+MemoryLayout(::Type{<:Zeros}) = ZerosLayout()
+MemoryLayout(::Type{<:Ones}) = OnesLayout()
+
+_copyto!(_, ::AbstractFillLayout, dest::AbstractArray{<:Any,N}, src::AbstractArray{<:Any,N}) where N =
+    fill!(dest, getindex_value(src))
+
+    _fill_copyto!(dest, C::Zeros) = zero!(dest) # exploit special fill! overload
+
+sub_materialize(::AbstractFillLayout, V, ax) = Fill(getindex_value(V), ax)
+sub_materialize(::ZerosLayout, V, ax) = Zeros{eltype(V)}(ax)
+sub_materialize(::OnesLayout, V, ax) = Ones{eltype(V)}(ax)
+
+*(x::AdjointAbsVec{<:Any,<:Zeros{<:Any,1}},   D::Diagonal, y::LayoutVector) = FillArrays._triple_zeromul(x, D, y)
+*(x::TransposeAbsVec{<:Any,<:Zeros{<:Any,1}}, D::Diagonal, y::LayoutVector) = FillArrays._triple_zeromul(x, D, y)
+
+@inline LinearAlgebra.dot(a::LayoutVector, b::AbstractFill{<:Any,1}) = FillArrays._fill_dot_rev(a,b)
+@inline LinearAlgebra.dot(a::AbstractFill{<:Any,1}, b::LayoutVector) = FillArrays._fill_dot(a,b)
+
+# TODO: Remove unnecessary _apply
+_apply(_, _, op, Λ::UniformScaling, A::AbstractMatrix) = op(Diagonal(Fill(Λ.λ,(axes(A,1),))), A)
+_apply(_, _, op, A::AbstractMatrix, Λ::UniformScaling) = op(A, Diagonal(Fill(Λ.λ,(axes(A,1),))))
+
+# equivalent to rescaling
+function materialize!(M::MulAdd{<:DiagonalLayout{<:AbstractFillLayout}})
+    checkdimensions(M)
+    M.C .= (M.α * getindex_value(M.A.diag)) .* M.B .+ M.β .* M.C
+    M.C
+end
+
+function materialize!(M::MulAdd{<:Any,<:DiagonalLayout{<:AbstractFillLayout}})
+    checkdimensions(M)
+    M.C .= M.α .* M.A .* getindex_value(M.B.diag) .+ M.β .* M.C
+    M.C
+end
+
+fillzeros(::Type{T}, ax) where T<:Number = Zeros{T}(ax)
+mulzeros(::Type{T}, M) where T<:Number = fillzeros(T, axes(M))
+mulzeros(::Type{T}, M::Mul{<:DualLayout,<:Any,<:Adjoint}) where T<:Number = fillzeros(T, axes(M,2))'
+mulzeros(::Type{T}, M::Mul{<:DualLayout,<:Any,<:Transpose}) where T<:Number = transpose(fillzeros(T, axes(M,2)))
+
+end

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -8,11 +8,6 @@ mulreduce(M::Mul{<:Any,<:DiagonalLayout}) = Rmul(M)
 
 # Diagonal multiplication never changes structure
 similar(M::Lmul{<:DiagonalLayout}, ::Type{T}, axes) where T = similar(M.B, T, axes)
-# equivalent to rescaling
-function materialize!(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout}})
-    M.B .= getindex_value(M.A.diag) .* M.B
-    M.B
-end
 
 
 copy(M::Lmul{<:DiagonalLayout,<:DiagonalLayout}) = diagonal(diagonaldata(M.A) .* diagonaldata(M.B))
@@ -32,11 +27,6 @@ end
 
 # Diagonal multiplication never changes structure
 similar(M::Rmul{<:Any,<:DiagonalLayout}, ::Type{T}, axes) where T = similar(M.A, T, axes)
-# equivalent to rescaling
-function materialize!(M::Rmul{<:Any,<:DiagonalLayout{<:AbstractFillLayout}})
-    M.A .= M.A .* getindex_value(M.B.diag)
-    M.A
-end
 
 
 function materialize!(M::Ldiv{<:DiagonalLayout})
@@ -46,13 +36,9 @@ end
 
 copy(M::Ldiv{<:DiagonalLayout,<:DiagonalLayout}) = diagonal(M.A.diag .\ M.B.diag)
 copy(M::Ldiv{<:DiagonalLayout}) = M.A.diag .\ M.B
-copy(M::Ldiv{<:DiagonalLayout{<:AbstractFillLayout}}) = inv(getindex_value(M.A.diag)) .* M.B
-copy(M::Ldiv{<:DiagonalLayout{<:AbstractFillLayout},<:DiagonalLayout}) = diagonal(inv(getindex_value(M.A.diag)) .* M.B.diag)
 
 copy(M::Rdiv{<:DiagonalLayout,<:DiagonalLayout}) = diagonal(M.A.diag .* inv.(M.B.diag))
 copy(M::Rdiv{<:Any,<:DiagonalLayout}) = M.A .* inv.(permutedims(M.B.diag))
-copy(M::Rdiv{<:Any,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A .* inv(getindex_value(M.B.diag))
-copy(M::Rdiv{<:DiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = diagonal(M.A.diag .* inv(getindex_value(M.B.diag)))
 
 
 
@@ -70,18 +56,6 @@ copy(M::Lmul{<:DiagonalLayout,DiagonalLayout{OnesLayout}}) = Diagonal(_copy_ofty
 copy(M::Lmul{DiagonalLayout{OnesLayout},DiagonalLayout{OnesLayout}}) = _copy_oftype(M.B, eltype(M))
 copy(M::Rmul{<:Any,DiagonalLayout{OnesLayout}}) = _copy_oftype(M.A, eltype(M))
 copy(M::Rmul{<:DualLayout,DiagonalLayout{OnesLayout}}) = _copy_oftype(M.A, eltype(M))
-
-copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout}}) = getindex_value(diagonaldata(M.A)) * M.B
-copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:DiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
-copy(M::Rmul{<:Any,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
-copy(M::Rmul{<:DualLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
-
-copy(M::Rmul{<:BidiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
-copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:BidiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
-copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
-copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:TridiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
-copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
-copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:SymTridiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
 
 
 copy(M::Rmul{<:BidiagonalLayout,DiagonalLayout{OnesLayout}}) = _copy_oftype(M.A, eltype(M))

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -531,22 +531,11 @@ struct ZerosLayout <: AbstractFillLayout end
 struct OnesLayout <: AbstractFillLayout end
 struct EyeLayout <: MemoryLayout end
 
-MemoryLayout(::Type{<:AbstractFill}) = FillLayout()
-MemoryLayout(::Type{<:Zeros}) = ZerosLayout()
-MemoryLayout(::Type{<:Ones}) = OnesLayout()
-
 # all sub arrays are same
 sublayout(L::AbstractFillLayout, inds::Type) = L
 reshapedlayout(L::AbstractFillLayout, _) = L
 adjointlayout(::Type, L::AbstractFillLayout) = L
 transposelayout(L::AbstractFillLayout) = L
-
-_copyto!(_, ::AbstractFillLayout, dest::AbstractArray{<:Any,N}, src::AbstractArray{<:Any,N}) where N =
-    fill!(dest, getindex_value(src))
-
-sub_materialize(::AbstractFillLayout, V, ax) = Fill(getindex_value(V), ax)
-sub_materialize(::ZerosLayout, V, ax) = Zeros{eltype(V)}(ax)
-sub_materialize(::OnesLayout, V, ax) = Ones{eltype(V)}(ax)
 
 abstract type AbstractBandedLayout <: MemoryLayout end
 abstract type AbstractTridiagonalLayout <: AbstractBandedLayout end


### PR DESCRIPTION
This is as far as I got. I got stuck at the `MulAdd(::Mul)` constructor, which calls `mulzeros`, which calls `Zeros` for `Number` eltypes. So, either this means we have a strong dependency, or there is a work-around. Perhaps, after https://github.com/JuliaArrays/FillArrays.jl/pull/286 FillArrays.jl is light enough anyway, but if there is a simple enough work-around, I think it would be still beneficial to reduce strong dependencies as much as possible. I'm leaving for summer holidays, so I'm putting this up for comments.