### PR TITLE
Add colsupport for OneElelement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -666,6 +666,9 @@ end
 rowsupport(::ZerosLayout, A, _) = 1:0
 colsupport(::ZerosLayout, A, _) = 1:0
 
+colsupport(::UnknownLayout, A::OneElement{<:Any,1}, _) =
+    intersect(axes(A,1), A.ind[1]:A.ind[1])
+
 rowsupport(::DiagonalLayout, _, k) = k
 colsupport(::DiagonalLayout, _, j) = j
 

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -313,6 +313,13 @@ struct FooNumber <: Number end
         @test isempty(colsupport(Zeros(5,10), 2))
         @test isempty(rowsupport(Zeros(5,10), 2))
 
+        @testset "OneElement" begin
+            for ind in (4, 20)
+                o = OneElement(2, ind, 10)
+                @test sum(o) == sum(o[colsupport(o)])
+            end
+        end
+
         # views of Fill no longer create Sub Arrays, but are supported
         # as there was no strong need to delete their support
         v = SubArray(Fill(1,10),(1:3,))


### PR DESCRIPTION
This allows one to define an efficient `BandedMatrix * OneElement`. Currently, I've gone against the trend a bit, and specialized on the array type as well as the memory layout, instead of defining a layout for `OneElement` (I wasn't quite sure if that might introduce ambiguities, but if this is desired, we may do it in another PR). 