### PR TITLE
Add 5-term Matrix-vector mul

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -256,6 +256,8 @@ macro layoutmul(Typ)
                 ArrayLayouts.mul!(dest,A,b)
             LinearAlgebra.mul!(dest::AbstractVector, A::$Mod{<:Any,<:$Typ}, b::AbstractVector) =
                 ArrayLayouts.mul!(dest,A,b)
+            LinearAlgebra.mul!(dest::AbstractVector, A::$Mod{<:Any,<:$Typ}, b::AbstractVector, α::Number, β::Number) =
+                ArrayLayouts.mul!(dest,A,b,α,β)
             LinearAlgebra.mul!(dest::AbstractMatrix, A::$Mod{<:Any,<:$Typ}, B::AbstractMatrix, α::Number, β::Number) =
                 ArrayLayouts.mul!(dest,A,B,α,β)
             LinearAlgebra.mul!(dest::AbstractMatrix, A::AbstractMatrix, B::$Mod{<:Any,<:$Typ}, α::Number, β::Number) =


### PR DESCRIPTION
This makes 
```julia
julia> A = brand(4,4,-2,2); w=rand(4);

julia> mul!(ones(size(A,2)), A', w, 1.0, 1.0)
4-element Vector{Float64}:
 1.0
 1.0
 1.3629633338145817
 1.2059646417643002
```
avoid generic fallbacks.