### PR TITLE
Replace ind2sub by CartesianIndices

### DIFF
--- a/src/mul.jl
+++ b/src/mul.jl
@@ -53,7 +53,11 @@ function _getindex(::Type{Tuple{AA,BB}}, M::Mul, (k, j)::Tuple{AA,BB}) where {AA
 end
 
 # linear indexing
-_getindex(::Type{NTuple{2,Int}}, M, k::Tuple{Int}) = M[Base._ind2sub(axes(M), k...)...]
+function _getindex(::Type{NTuple{2,Int}}, M, k::Tuple{Int})
+    # convert from linear to CartesianIndex
+    CartInd = CartesianIndices(axes(M))[k...]
+    M[Tuple(CartInd)...]
+end
 
 _getindex(::Type{Tuple{Int}}, M, (k,)::Tuple{CartesianIndex{1}}) = M[convert(Int, k)]
 _getindex(::Type{NTuple{2,Int}}, M, (kj,)::Tuple{CartesianIndex{2}}) = M[kj[1], kj[2]]


### PR DESCRIPTION
This avoids calling the internal function `_ind2sub`, and uses a `CartesianIndex` instead.