### PR TITLE
Add `mul` methods for `AbstractTriangular` of `LayoutMatrix`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.4.5"
+version = "1.5.0"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -252,7 +252,7 @@ macro layoutmul(Typ)
             (*)(A::$Typ, B::LinearAlgebra.$Struc) = ArrayLayouts.mul(A,B)
         end
     end
-    for Mod in (:Adjoint, :Transpose, :Symmetric, :Hermitian)
+    for Mod in (:Adjoint, :Transpose, :Symmetric, :Hermitian, :AbstractTriangular)
         ret = quote
             $ret
 


### PR DESCRIPTION
This makes operations like
```julia
julia> A = BandedBlockBandedMatrix{Float64}(undef, 1:10,1:10, (1,1), (1,1));

julia> A.data .= randn.();

julia> U = UnitUpperTriangular(A);

julia> b = randn(size(U,1));

julia> U * b
```
use layout-based `mul` methods instead of hitting a default fallback.