### PR TITLE
Store if `C isa Zeros` in a `MulAdd`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.5.3"
+version = "1.6.0"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/muladd.jl
+++ b/src/muladd.jl
@@ -9,7 +9,9 @@ struct MulAdd{StyleA, StyleB, StyleC, T, AA, BB, CC}
     B::BB
     β::T
     C::CC
-    Czero::Bool # this flag indicates whether and C isa Zeros, or a copy of one
+    Czero::Bool # this flag indicates whether C isa Zeros, or a copy of one
+    # the idea is that if Czero == true, then downstream packages don't need to
+    # fill C with zero before performing the muladd
 end
 
 @inline function MulAdd{StyleA,StyleB,StyleC}(α::T, A::AA, B::BB, β::T, C::CC;

--- a/src/muladd.jl
+++ b/src/muladd.jl
@@ -9,12 +9,12 @@ struct MulAdd{StyleA, StyleB, StyleC, T, AA, BB, CC}
     B::BB
     β::T
     C::CC
-    CZeros::Bool # this flag indicates whether and C isa Zeros, or a copy of one
+    Czero::Bool # this flag indicates whether and C isa Zeros, or a copy of one
 end
 
 @inline function MulAdd{StyleA,StyleB,StyleC}(α::T, A::AA, B::BB, β::T, C::CC;
-            CZeros = C isa Zeros) where {StyleA,StyleB,StyleC,T,AA,BB,CC}
-    MulAdd{StyleA,StyleB,StyleC,T,AA,BB,CC}(α,A,B,β,C,CZeros)
+            Czero = C isa Zeros) where {StyleA,StyleB,StyleC,T,AA,BB,CC}
+    MulAdd{StyleA,StyleB,StyleC,T,AA,BB,CC}(α,A,B,β,C,Czero)
 end
 
 @inline function MulAdd{StyleA,StyleB,StyleC}(αT, A, B, βV, C; kw...) where {StyleA,StyleB,StyleC}
@@ -78,7 +78,7 @@ _fill_copyto!(dest, C) = copyto!(dest, C)
 _fill_copyto!(dest, C::Zeros) = zero!(dest) # exploit special fill! overload
 
 @inline copyto!(dest::AbstractArray{T}, M::MulAdd) where T =
-    muladd!(M.α, unalias(dest,M.A), unalias(dest,M.B), M.β, _fill_copyto!(dest, M.C); CZeros = M.CZeros)
+    muladd!(M.α, unalias(dest,M.A), unalias(dest,M.B), M.β, _fill_copyto!(dest, M.C); Czero = M.Czero)
 
 # Modified from LinearAlgebra._generic_matmatmul!
 const tilebufsize = 10800  # Approximately 32k/3


### PR DESCRIPTION
The idea is that this flag will help downstream. If `C isa Zeros` (as in `MulAdd(::Mul)`), the destination is explicitly zeroed by calling `_fill_copyto!` in `muladd!`. Storing this information would mean that we would be able to save an additional zero-`fill!` downstream.

The impact:
```julia
julia> B = brand(6000,6000,4000,4000);

julia> O = OneElement(1, 3, size(B,2));

julia> @btime $B * $O;
  4.203 μs (2 allocations: 46.92 KiB) # master
  3.839 μs (2 allocations: 46.92 KiB) # PR

julia> @btime $B[:, 3]; # the matrix multiplication with a OneElementMatrix is now equally fast as slicing
  3.936 μs (4 allocations: 47.00 KiB)
```