### PR TITLE
Change exact comparison with LAPACK.gesv to approx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.jl.mem
 deps/deps.jl
 Manifest.toml
+Manifest-v*.*.toml
 .DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -14,7 +14,7 @@ Base.size(A::MyMatrix) = size(A.A)
 Base.strides(A::MyMatrix) = strides(A.A)
 Base.elsize(::Type{MyMatrix}) = sizeof(Float64)
 Base.cconvert(::Type{Ptr{Float64}}, A::MyMatrix) = A.A
-Base.unsafe_convert(::Type{Ptr{Float64}}, A::MyMatrix) = Base.unsafe_convert(Ptr{T}, A.A)
+Base.unsafe_convert(::Type{Ptr{Float64}}, A::MyMatrix) = Base.unsafe_convert(Ptr{Float64}, A.A)
 MemoryLayout(::Type{MyMatrix}) = DenseColumnMajor()
 Base.copy(A::MyMatrix) = MyMatrix(copy(A.A))
 
@@ -28,7 +28,7 @@ Base.size(A::MyVector) = size(A.A)
 Base.strides(A::MyVector) = strides(A.A)
 Base.elsize(::Type{MyVector}) = sizeof(Float64)
 Base.cconvert(::Type{Ptr{T}}, A::MyVector{T}) where {T} = A.A
-Base.unsafe_convert(::Type{Ptr{T}}, A::MyVector) where T = Base.unsafe_convert(Ptr{T}, A.A)
+Base.unsafe_convert(::Type{Ptr{T}}, A::MyVector{T}) where T = Base.unsafe_convert(Ptr{T}, A.A)
 MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
 
 # These need to test dispatch reduces to ArrayLayouts.mul, etc.

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -13,7 +13,8 @@ Base.setindex!(A::MyMatrix, v, k::Int, j::Int) = setindex!(A.A, v, k, j)
 Base.size(A::MyMatrix) = size(A.A)
 Base.strides(A::MyMatrix) = strides(A.A)
 Base.elsize(::Type{MyMatrix}) = sizeof(Float64)
-Base.unsafe_convert(::Type{Ptr{T}}, A::MyMatrix) where T = Base.unsafe_convert(Ptr{T}, A.A)
+Base.cconvert(::Type{Ptr{Float64}}, A::MyMatrix) = A.A
+Base.unsafe_convert(::Type{Ptr{Float64}}, A::MyMatrix) = Base.unsafe_convert(Ptr{T}, A.A)
 MemoryLayout(::Type{MyMatrix}) = DenseColumnMajor()
 Base.copy(A::MyMatrix) = MyMatrix(copy(A.A))
 
@@ -26,6 +27,7 @@ Base.setindex!(A::MyVector, v, k::Int) = setindex!(A.A, v, k)
 Base.size(A::MyVector) = size(A.A)
 Base.strides(A::MyVector) = strides(A.A)
 Base.elsize(::Type{MyVector}) = sizeof(Float64)
+Base.cconvert(::Type{Ptr{T}}, A::MyVector{T}) where {T} = A.A
 Base.unsafe_convert(::Type{Ptr{T}}, A::MyVector) where T = Base.unsafe_convert(Ptr{T}, A.A)
 MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
 

--- a/test/test_ldiv.jl
+++ b/test/test_ldiv.jl
@@ -44,7 +44,7 @@ import ArrayLayouts: ApplyBroadcastStyle, QRCompactWYQLayout, QRCompactWYLayout,
         b = randn(T,5)
         @test copyto!(similar(b), Ldiv(A,b)) ==
                     (similar(b) .= Ldiv(A,b)) ==
-                  (A\b) == (b̃ =  copy(b); LAPACK.gesv!(copy(A), b̃); b̃)
+                  (A\b) ≈ (b̃ =  copy(b); LAPACK.gesv!(copy(A), b̃); b̃)
 
         @test copyto!(similar(b), Ldiv(UpperTriangular(A) , b)) ≈ UpperTriangular(A) \ b
         @test copyto!(similar(b), Ldiv(UpperTriangular(A) , b)) ==


### PR DESCRIPTION
The result of `LAPACK.gesv!` has changed slightly between v1.10 and v1.11, so the exact equality doesn't hold anymore. This result is not guaranteed to be stable across versions, and only an approximate equality is guaranteed to hold.

Also specialize `Base.cconvert` for some of the test array types, as this is used by `pointer` on v1.11.