### PR TITLE
Fix sort for RangeCumSum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -7,7 +7,7 @@ using Base: AbstractCartesianIndex, OneTo, oneto, RangeIndex, ReinterpretArray, 
             Slice, tuple_type_tail, unalias,
             @propagate_inbounds
 
-import Base: axes, size, length, eltype, ndims, first, last, diff, isempty, union, sort!,
+import Base: axes, size, length, eltype, ndims, first, last, diff, isempty, union, sort!, sort,
                 ==, *, +, -, /, \, copy, copyto!, similar, getproperty, getindex, strides,
                 reverse, unsafe_convert, convert, view
 

--- a/src/cumsum.jl
+++ b/src/cumsum.jl
@@ -37,6 +37,7 @@ isempty(r::RangeCumsum) = isempty(r.range)
 union(a::RangeCumsum{<:Any,<:OneTo}, b::RangeCumsum{<:Any,<:OneTo}) =
     RangeCumsum(OneTo(max(last(a.range), last(b.range))))
 
-sort!(a::RangeCumsum{<:Any,<:AbstractUnitRange}) = a
+sort!(a::RangeCumsum{<:Any,<:Base.OneTo}) = a
+sort(a::RangeCumsum{<:Any,<:Base.OneTo}) = a
 
 convert(::Type{RangeCumsum{T,R}}, r::RangeCumsum) where {T,R} = RangeCumsum{T,R}(convert(R, r.range))

--- a/test/test_cumsum.jl
+++ b/test/test_cumsum.jl
@@ -19,7 +19,11 @@ include("infinitearrays.jl")
 
     a,b = RangeCumsum(Base.OneTo(5)), RangeCumsum(Base.OneTo(6))
     @test union(a,b) ≡ union(b,a) ≡ b
-    @test sort!(a) ≡ a
+    @test sort!(a) ≡ a == Vector(a)
+    @test sort(a) ≡ a == Vector(a)
+
+    r = RangeCumsum(-4:4)
+    @test sort(r) == sort(Vector(r))
 
     a = RangeCumsum(Base.OneTo(3))
     b = RangeCumsum(1:3)

--- a/test/test_cumsum.jl
+++ b/test/test_cumsum.jl
@@ -19,7 +19,8 @@ include("infinitearrays.jl")
 
     a,b = RangeCumsum(Base.OneTo(5)), RangeCumsum(Base.OneTo(6))
     @test union(a,b) ≡ union(b,a) ≡ b
-    @test sort!(a) ≡ a == Vector(a)
+    @test sort!(copy(a)) == a
+    @test sort!(a) ≡ a
     @test sort(a) ≡ a == Vector(a)
 
     r = RangeCumsum(-4:4)


### PR DESCRIPTION
The in-place sort should only be defined for `Base.OneTo` cumsums, as otherwise we can't guarantee an increasing result.