### PR TITLE
Run doc job on v1.10

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.10'
       - run: |
           julia --project=docs -e '
             using Pkg


### PR DESCRIPTION
This will reduce potential breakages from changes in the display of types.