### PR TITLE
Avoid overflow in indexing and sum

### DIFF
--- a/src/cumsum.jl
+++ b/src/cumsum.jl
@@ -18,9 +18,11 @@ BroadcastStyle(::Type{<:RangeCumsum{<:Any,RR}}) where RR = BroadcastStyle(RR)
 _half(x::Integer) = x ÷ 2
 _half(x) = x / 2
 
-_half_prod(a, b) = _half(a) * b
 function _half_prod(a::Integer, b::Integer)
-    iseven(a) ? (a ÷ 2) * b : a * (b ÷ 2)
+    iseven(a) ? (a÷2) * b : a * (b÷2)
+end
+function _onethird_prod(a::Integer, b::Integer)
+    mod(a, 3) == 0 ? (a÷3) * b : a * (b÷3)
 end
 
 function _getindex(r::AbstractRange{<:Real}, k)
@@ -45,10 +47,6 @@ first(r::RangeCumsum) = first(r.range)
 last(r::RangeCumsum) = sum(r.range)
 diff(r::RangeCumsum) = r.range[firstindex(r)+1:end]
 isempty(r::RangeCumsum) = isempty(r.range)
-
-function _onethird_prod(a::Integer, b::Integer)
-    mod(a, 3) == 0 ? (a÷3) * b : a * (b÷3)
-end
 
 function Base.sum(r::RangeCumsum{<:Real})
     N = length(r)

--- a/src/cumsum.jl
+++ b/src/cumsum.jl
@@ -46,7 +46,7 @@ last(r::RangeCumsum) = sum(r.range)
 diff(r::RangeCumsum) = r.range[firstindex(r)+1:end]
 isempty(r::RangeCumsum) = isempty(r.range)
 
-function _third_prod(a::Integer, b::Integer)
+function _onethird_prod(a::Integer, b::Integer)
     mod(a, 3) == 0 ? (a÷3) * b : a * (b÷3)
 end
 
@@ -56,7 +56,7 @@ function Base.sum(r::RangeCumsum{<:Real})
     s = step(r.range)
     # avoid overflow, if possible
     halfnnp1 = _half_prod(N, N+1)
-    v * halfnnp1 + s * _third_prod(halfnnp1, N-1)
+    v * halfnnp1 + s * _onethird_prod(halfnnp1, N-1)
 end
 
 union(a::RangeCumsum{<:Any,<:OneTo}, b::RangeCumsum{<:Any,<:OneTo}) =

--- a/src/cumsum.jl
+++ b/src/cumsum.jl
@@ -15,9 +15,6 @@ Base.parent(r::RangeCumsum) = r.range
 ==(a::RangeCumsum, b::RangeCumsum) = a.range == b.range
 BroadcastStyle(::Type{<:RangeCumsum{<:Any,RR}}) where RR = BroadcastStyle(RR)
 
-_half(x::Integer) = x ÷ 2
-_half(x) = x / 2
-
 function _half_prod(a::Integer, b::Integer)
     iseven(a) ? (a÷2) * b : a * (b÷2)
 end

--- a/test/test_cumsum.jl
+++ b/test/test_cumsum.jl
@@ -51,6 +51,17 @@ cmpop(p) = isinteger(real(first(p))) && isinteger(real(step(p))) ? (==) : (≈)
     r = RangeCumsum(InfiniteArrays.OneToInf())
     @test axes(r, 1) == InfiniteArrays.OneToInf()
 
+    @testset "overflow" begin
+        r = RangeCumsum(typemax(Int)÷2 .+ (0:1))
+        @test last(r) == typemax(Int)
+        r = RangeCumsum(typemin(Int)÷2 .- (1:1))
+        @test first(r) == typemin(Int)÷2 - 1
+        r = RangeCumsum(typemax(Int) .+ (0:0))
+        @test sum(r) == typemax(Int)
+        r = RangeCumsum(typemin(Int) .+ (0:0))
+        @test sum(r) == typemin(Int)
+    end
+
     @testset "multiplication by a number" begin
         function test_broadcast(n, r)
             w = Vector(r)


### PR DESCRIPTION
Avoid overflows in indexing a `RangeCumsum` by being careful with factors.

On master
```julia
julia> r = RangeCumsum(typemax(Int) .+ (0:0))
1-element RangeCumsum{Int64, UnitRange{Int64}}:
 9223372036854775807

julia> sum(r)
-1
```
This PR
```julia
julia> sum(r)
9223372036854775807
```