### PR TITLE
Show for RangeCumsum

### DIFF
--- a/src/cumsum.jl
+++ b/src/cumsum.jl
@@ -71,3 +71,5 @@ end
 function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{1}, ::typeof(*), r::RangeCumsum, x::Number)
     RangeCumsum(r.range * x)
 end
+
+Base.show(io::IO, r::RangeCumsum) = print(io, RangeCumsum, "(", r.range, ")")

--- a/test/test_cumsum.jl
+++ b/test/test_cumsum.jl
@@ -33,6 +33,7 @@ cmpop(p) = isinteger(real(first(p))) && isinteger(real(step(p))) ? (==) : (≈)
         @test diff(r) == p[firstindex(p)+1:end]
         @test last(r) == r[end] == sum(p)
         @test first(r) == r[firstindex(r)] == first(p)
+        @test repr(r) == "$RangeCumsum($p)"
     end
 
     a,b = RangeCumsum(Base.OneTo(5)), RangeCumsum(Base.OneTo(6))


### PR DESCRIPTION
After this, the displayed form becomes a valid constructor:
```julia
julia> r = RangeCumsum(1:2)
2-element RangeCumsum{Int64, UnitRange{Int64}}:
 1
 3

julia> show(r)
RangeCumsum(1:2)
```