### PR TITLE
`promote_rule` for `RangeCumSum`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.8.0"
+version = "1.9.0-dev"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/cumsum.jl
+++ b/src/cumsum.jl
@@ -12,6 +12,11 @@ axes(c::RangeCumsum) = axes(c.range)
 
 Base.parent(r::RangeCumsum) = r.range
 
+function Base.promote_rule(::Type{RangeCumsum{T1, R1}}, ::Type{RangeCumsum{T2, R2}}) where {T1,T2,R1,R2}
+    R = promote_type(R1, R2)
+    RangeCumsum{promote_type(T1, T2), R}
+end
+
 ==(a::RangeCumsum, b::RangeCumsum) = a.range == b.range
 BroadcastStyle(::Type{<:RangeCumsum{<:Any,RR}}) where RR = BroadcastStyle(RR)
 

--- a/test/test_cumsum.jl
+++ b/test/test_cumsum.jl
@@ -36,6 +36,12 @@ cmpop(p) = isinteger(real(first(p))) && isinteger(real(step(p))) ? (==) : (≈)
         @test repr(r) == "$RangeCumsum($p)"
     end
 
+    @testset "promote" begin
+        r1 = RangeCumsum(Int8(1):Int8(3))
+        r2 = RangeCumsum(Float32(1):Float32(3))
+        @test promote(r1, r2) == (r2, r2)
+    end
+
     a,b = RangeCumsum(Base.OneTo(5)), RangeCumsum(Base.OneTo(6))
     @test union(a,b) ≡ union(b,a) ≡ b
     @test sort!(copy(a)) == a


### PR DESCRIPTION
This allows us to promote two `RangeCumsum` instances to a common type.