### PR TITLE
Backports to fix 0.18 on 1.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.8.18"
+version = "0.8.19"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -51,7 +51,15 @@ else
     const CRowMaximum = RowMaximum
     const CNoPivot = NoPivot
 end
-        
+
+if VERSION ≥ v"1.11.0-DEV.21"
+    using LinearAlgebra: UpperOrLowerTriangular
+else
+    const UpperOrLowerTriangular{T,S} = Union{LinearAlgebra.UpperTriangular{T,S},
+                                              LinearAlgebra.UnitUpperTriangular{T,S},
+                                              LinearAlgebra.LowerTriangular{T,S},
+                                              LinearAlgebra.UnitLowerTriangular{T,S}}
+end
 
 struct ApplyBroadcastStyle <: BroadcastStyle end
 @inline function copyto!(dest::AbstractArray, bc::Broadcasted{ApplyBroadcastStyle})
@@ -146,7 +154,7 @@ end
 macro layoutgetindex(Typ)
     esc(quote
         ArrayLayouts.@_layoutgetindex $Typ
-        ArrayLayouts.@_layoutgetindex LinearAlgebra.AbstractTriangular{<:Any,<:$Typ}
+        ArrayLayouts.@_layoutgetindex ArrayLayouts.UpperOrLowerTriangular{<:Any,<:$Typ}
         ArrayLayouts.@_layoutgetindex LinearAlgebra.Symmetric{<:Any,<:$Typ}
         ArrayLayouts.@_layoutgetindex LinearAlgebra.Hermitian{<:Any,<:$Typ}
         ArrayLayouts.@_layoutgetindex LinearAlgebra.Adjoint{<:Any,<:$Typ}
@@ -351,7 +359,7 @@ Base.replace_in_print_matrix(A::Union{LayoutVector,
 Base.print_matrix_row(io::IO,
         X::Union{LayoutMatrix,
         LayoutVector,
-        AbstractTriangular{<:Any,<:LayoutMatrix},
+        UpperOrLowerTriangular{<:Any,<:LayoutMatrix},
         AdjOrTrans{<:Any,<:LayoutMatrix},
         AdjOrTrans{<:Any,<:LayoutVector},
         HermOrSym{<:Any,<:LayoutMatrix},

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -709,8 +709,8 @@ end
 
 axes(A::HermOrSym{<:Any,<:LayoutMatrix}) = _sym_axes(A)
 axes(A::HermOrSym{<:Any,<:SubArray{<:Any,2,<:LayoutMatrix}}) = _sym_axes(A)
-axes(A::AbstractTriangular{<:Any,<:LayoutMatrix}) = axes(parent(A))
-axes(A::AbstractTriangular{<:Any,<:SubArray{<:Any,2,<:LayoutMatrix}}) = axes(parent(A))
+axes(A::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}) = axes(parent(A))
+axes(A::UpperOrLowerTriangular{<:Any,<:SubArray{<:Any,2,<:LayoutMatrix}}) = axes(parent(A))
 
 function axes(D::Diagonal{<:Any,<:LayoutVector})
     a = axes(parent(D),1)

--- a/test/test_ldiv.jl
+++ b/test/test_ldiv.jl
@@ -42,7 +42,7 @@ import ArrayLayouts: ApplyBroadcastStyle, QRCompactWYQLayout, QRCompactWYLayout,
         b = randn(T,5)
         @test all(copyto!(similar(b), Ldiv(A,b)) .===
                     (similar(b) .= Ldiv(A,b)) .===
-                  (A\b) .=== (b̃ =  copy(b); LAPACK.gesv!(copy(A), b̃); b̃))
+                  (A\b) ≈ (b̃ =  copy(b); LAPACK.gesv!(copy(A), b̃); b̃))
 
         @test copyto!(similar(b), Ldiv(UpperTriangular(A) , b)) ≈ UpperTriangular(A) \ b
         @test all(copyto!(similar(b), Ldiv(UpperTriangular(A) , b)) .===
@@ -94,7 +94,7 @@ import ArrayLayouts: ApplyBroadcastStyle, QRCompactWYQLayout, QRCompactWYLayout,
         @test LowerTriangular(A') \ B ≈ copyto!(similar(B) , Ldiv(LowerTriangular(A'), B)) ≈ (B .= Ldiv(LowerTriangular(A'), B))
         @test UnitUpperTriangular(A) \ B ≈ copyto!(similar(B) , Ldiv(UnitUpperTriangular(A), B)) ≈ (B .= Ldiv(UnitUpperTriangular(A), B))
         @test UnitUpperTriangular(A') \ B ≈ copyto!(similar(B) , Ldiv(UnitUpperTriangular(A'), B)) ≈ (B .= Ldiv(UnitUpperTriangular(A'), B))
-        @test UnitLowerTriangular(A') \ B ≈ copyto!(similar(B) , Ldiv(UnitLowerTriangular(A'), B)) ≈ (B .= Ldiv(UnitLowerTriangular(A'), B))        
+        @test UnitLowerTriangular(A') \ B ≈ copyto!(similar(B) , Ldiv(UnitLowerTriangular(A'), B)) ≈ (B .= Ldiv(UnitLowerTriangular(A'), B))
 
         C = randn(5,5) + im * randn(5,5)
         D = randn(5,5) + im * randn(5,5)
@@ -285,4 +285,3 @@ import ArrayLayouts: ApplyBroadcastStyle, QRCompactWYQLayout, QRCompactWYLayout,
         @test_broken ArrayLayouts.rdiv!(similar(B), D, B) ==  D / B
     end
 end
-


### PR DESCRIPTION
Unfortunately, quite a lot of packages seem to be stuck at ArrayLayouts < 1.0 which errors on 1.11 due to the number of parameters change in the triangular array.

This backports the fixes so that this package passes test on 0.18 so that the packages stuff on older version keep working. Normally I wouldn't bother with this but there were enough packages that I felt it made sense.

A maintainer here would have to:

- create a `release-0.18` branch from this commit https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl/commit/449a3e5966691feb67456a7d919620cac911f75b
- merge this PR into that branch
- make a new release from that merge commit

This should release 0.18.19 which should work on 1.11.