### PR TITLE
Fix failing QR scaling test on v1.6

### DIFF
--- a/test/test_muladd.jl
+++ b/test/test_muladd.jl
@@ -615,7 +615,11 @@ Random.seed!(0)
         Q = qr(randn(5,5)).Q
         b = randn(5)
         B = randn(5,5)
-        @test Q*1.0 == ArrayLayouts.lmul!(Q, Matrix{Float64}(I, 5, 5))
+        # The approx equality becomes exact on v1.10 and above,
+        # but that's an implementation detail.
+        # Below this, the LHS uses matrix broadcasting, whereas above this,
+        # it uses GEMQRT like the RHS
+        @test Q*1.0 ≈ ArrayLayouts.lmul!(Q, Matrix{Float64}(I, 5, 5))
         @test Q*b == ArrayLayouts.lmul!(Q, copy(b)) == mul(Q,b)
         @test Q*B == ArrayLayouts.lmul!(Q, copy(B)) == mul(Q,B)
         @test B*Q == ArrayLayouts.rmul!(copy(B), Q) == mul(B,Q)
@@ -634,7 +638,11 @@ Random.seed!(0)
         Q = qr(randn(7,5)).Q
         b = randn(5)
         B = randn(5,5)
-        @test Q*1.0 == ArrayLayouts.lmul!(Q, Matrix{Float64}(I, 7, 7))
+        # The approx equality becomes exact on v1.10 and above,
+        # but that's an implementatio detail.
+        # Below this, the LHS uses matrix broadcasting, whereas above this,
+        # it uses GEMQRT like the RHS
+        @test Q*1.0 ≈ ArrayLayouts.lmul!(Q, Matrix{Float64}(I, 7, 7))
         @test Q*b == mul(Q,b)
         @test Q*B == mul(Q,B)
         @test 1.0*Q ≈ ArrayLayouts.rmul!(Matrix{Float64}(I, 7, 7), Q)


### PR DESCRIPTION
This seems somewhat architecture dependent, as I can't reproduce the failure locally.