### PR TITLE
Add * for more matrices defined from layouts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.10.1"
+version = "1.10.2"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -219,6 +219,8 @@ end
 *(A::Diagonal{<:Any,<:LayoutVector}, B::Diagonal{<:Any,<:LayoutVector}) = mul(A, B)
 *(A::Diagonal{<:Any,<:LayoutVector}, B::AbstractMatrix) = mul(A, B)
 *(A::AbstractMatrix, B::Diagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::Union{Bidiagonal, Tridiagonal}, B::Diagonal{<:Any, <:LayoutVector}) = mul(A, B) # ambiguity
+*(A::Diagonal{<:Any, <:LayoutVector}, B::Union{Bidiagonal, Tridiagonal}) = mul(A, B) # ambiguity
 *(A::Diagonal{<:Any,<:LayoutVector}, B::LayoutMatrix) = mul(A, B)
 *(A::LayoutMatrix, B::Diagonal{<:Any,<:LayoutVector}) = mul(A, B)
 *(A::UpperTriangular, B::Diagonal{<:Any,<:LayoutVector}) = mul(A, B)

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -362,6 +362,25 @@ end
 *(A::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}, B::UpperOrLowerTriangular{<:Any,<:AdjOrTrans{<:Any,<:LayoutMatrix}}) = mul(A, B)
 *(A::UpperOrLowerTriangular{<:Any,<:AdjOrTrans{<:Any,<:LayoutMatrix}}, B::UpperOrLowerTriangular{<:Any,<:AdjOrTrans{<:Any,<:LayoutMatrix}}) = mul(A, B)
 
+*(A::SymTridiagonal{<:Any,<:LayoutVector}, B::SymTridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::SymTridiagonal{<:Any,<:LayoutVector}, B::Tridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::SymTridiagonal{<:Any,<:LayoutVector}, B::Bidiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::SymTridiagonal{<:Any,<:LayoutVector}, B::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}) = mul(A, B)
+*(A::SymTridiagonal, B::Diagonal{<:Any,<:LayoutVector}) = mul(A, B) # ambiguity
+*(A::Tridiagonal{<:Any,<:LayoutVector}, B::Tridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::Tridiagonal{<:Any,<:LayoutVector}, B::SymTridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::Tridiagonal{<:Any,<:LayoutVector}, B::Bidiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::Tridiagonal{<:Any,<:LayoutVector}, B::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}) = mul(A, B)
+*(A::Bidiagonal{<:Any,<:LayoutVector}, B::Bidiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::Bidiagonal{<:Any,<:LayoutVector}, B::SymTridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::Bidiagonal{<:Any,<:LayoutVector}, B::Tridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::Bidiagonal{<:Any,<:LayoutVector}, B::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}) = mul(A, B)
+*(A::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}, B::SymTridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}, B::Tridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}, B::Bidiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}, B::Diagonal{<:Any,<:LayoutVector}) = mul(A, B) # ambiguity
+*(A::Diagonal{<:Any,<:LayoutVector}, B::SymTridiagonal{<:Any,<:LayoutVector}) = mul(A, B)
+*(A::Diagonal{<:Any,<:LayoutVector}, B::UpperOrLowerTriangular{<:Any,<:LayoutMatrix}) = mul(A, B)
 
 # mul! for subarray of layout matrix
 const SubLayoutMatrix = Union{SubArray{<:Any,2,<:LayoutMatrix}, SubArray{<:Any,2,<:AdjOrTrans{<:Any,<:LayoutMatrix}}}

--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -1,8 +1,17 @@
 # Infinite Arrays implementation from
 # https://github.com/JuliaLang/julia/blob/master/test/testhelpers/InfiniteArrays.jl
 module InfiniteArrays
-    using Infinities
-    export OneToInf
+    using Infinities, LinearAlgebra, Random
+    using ..ArrayLayouts: ArrayLayouts, LayoutVector, LayoutMatrix, Mul, DenseColumnMajor
+    export OneToInf,
+        InfSymTridiagonal,
+        InfTridiagonal,
+        InfBidiagonal,
+        InfUnitUpperTriangular,
+        InfUnitLowerTriangular,
+        InfUpperTriangular,
+        InfLowerTriangular,
+        InfDiagonal 
 
     abstract type AbstractInfUnitRange{T<:Real} <: AbstractUnitRange{T} end
     Base.length(r::AbstractInfUnitRange) = ℵ₀
@@ -48,4 +57,69 @@ module InfiniteArrays
         @boundscheck checkbounds(v, first(i))
         v[first(i)]:ℵ₀
     end
+
+    ## Methods for testing infinite arrays 
+    struct InfVec{RNG} <: LayoutVector{Float64} # show is broken for InfVec
+        rng::RNG
+        data::Vector{Float64}
+    end
+    InfVec() = InfVec(copy(Random.seed!(Random.default_rng(), rand(UInt64))), Float64[])
+    function resizedata!(v::InfVec, i)
+        n = length(v.data)
+        i ≤ n && return v
+        resize!(v.data, i)
+        for j in (n+1):i
+            v[j] = rand(v.rng)
+        end
+        return v
+    end
+    Base.getindex(v::InfVec, i::Int) = (resizedata!(v, i); v.data[i])
+    Base.setindex!(v::InfVec, r, i::Int) = setindex!(v.data, r, i)
+    Base.size(v::InfVec) = (ℵ₀,)
+    Base.axes(v::InfVec) = (OneToInf(),)
+    ArrayLayouts.MemoryLayout(::Type{<:InfVec}) = DenseColumnMajor()
+    Base.similar(v::InfVec, ::Type{T}, ::Tuple{OneToInf{Int}}) where {T} = InfVec()
+    Base.copy(v::InfVec) = InfVec(copy(v.rng), copy(v.data))
+
+    struct InfMat{RNG} <: LayoutMatrix{Float64} # show is broken for InfMat
+        vec::InfVec{RNG}
+    end
+    InfMat() = InfMat(InfVec())
+    function diagtrav_idx(i, j)
+        band = i + j - 1
+        nelm = (band * (band - 1)) ÷ 2
+        return nelm + i
+    end
+    Base.getindex(A::InfMat, i::Int, j::Int) = A.vec[diagtrav_idx(i, j)]
+    Base.setindex!(A::InfMat, r, i::Int, j::Int) = setindex!(A.vec, r, diagtrav_idx(i, j))
+    Base.size(A::InfMat) = (ℵ₀, ℵ₀)
+    Base.axes(v::InfMat) = (OneToInf(), OneToInf())
+    ArrayLayouts.MemoryLayout(::Type{<:InfMat}) = DenseColumnMajor()
+    Base.copy(A::InfMat) = InfMat(copy(A.vec))
+
+    const InfSymTridiagonal = SymTridiagonal{Float64,InfVec{Xoshiro}}
+    const InfTridiagonal = Tridiagonal{Float64,InfVec{Xoshiro}}
+    const InfBidiagonal = Bidiagonal{Float64,InfVec{Xoshiro}}
+    const InfUnitUpperTriangular = UnitUpperTriangular{Float64,InfMat{Xoshiro}}
+    const InfUnitLowerTriangular = UnitLowerTriangular{Float64,InfMat{Xoshiro}}
+    const InfUpperTriangular = UpperTriangular{Float64,InfMat{Xoshiro}}
+    const InfLowerTriangular = LowerTriangular{Float64,InfMat{Xoshiro}}
+    const InfDiagonal = Diagonal{Float64,InfVec{Xoshiro}}
+    InfSymTridiagonal() = SymTridiagonal(InfVec(), InfVec())
+    InfTridiagonal() = Tridiagonal(InfVec(), InfVec(), InfVec())
+    InfBidiagonal(uplo) = Bidiagonal(InfVec(), InfVec(), uplo)
+    InfUnitUpperTriangular() = UnitUpperTriangular(InfMat())
+    InfUnitLowerTriangular() = UnitLowerTriangular(InfMat())
+    InfUpperTriangular() = UpperTriangular(InfMat())
+    InfLowerTriangular() = LowerTriangular(InfMat())
+    InfDiagonal() = Diagonal(InfVec())
+    Base.copy(D::InfDiagonal) = Diagonal(copy(D.diag))
+
+    # Without LazyArrays we have no access to the lazy machinery, so we must define copy(::Mul) to leave mul(A, B) as a lazy Mul(A, B)
+    const InfNamedMatrix = Union{InfSymTridiagonal,InfTridiagonal,InfBidiagonal,
+        InfUnitUpperTriangular,InfUnitLowerTriangular,
+        InfUpperTriangular,InfLowerTriangular,
+        InfDiagonal}
+    const InfMul{L1,L2} = Mul{L1,L2,<:InfNamedMatrix,<:InfNamedMatrix}
+    Base.copy(M::InfMul{L1,L2}) where {L1,L2} = Mul{L1,L2}(copy(M.A), copy(M.B))
 end

--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -100,10 +100,10 @@ module InfiniteArrays
     const InfSymTridiagonal = SymTridiagonal{Float64,<:InfVec}
     const InfTridiagonal = Tridiagonal{Float64,<:InfVec}
     const InfBidiagonal = Bidiagonal{Float64,<:InfVec}
-    const InfUnitUpperTriangular = UnitUpperTriangular{Float64,InfMat{Xoshiro}}
-    const InfUnitLowerTriangular = UnitLowerTriangular{Float64,InfMat{Xoshiro}}
-    const InfUpperTriangular = UpperTriangular{Float64,InfMat{Xoshiro}}
-    const InfLowerTriangular = LowerTriangular{Float64,InfMat{Xoshiro}}
+    const InfUnitUpperTriangular = UnitUpperTriangular{Float64,<:InfMat}
+    const InfUnitLowerTriangular = UnitLowerTriangular{Float64,<:InfMat}
+    const InfUpperTriangular = UpperTriangular{Float64,<:InfMat}
+    const InfLowerTriangular = LowerTriangular{Float64,<:InfMat}
     const InfDiagonal = Diagonal{Float64,<:InfVec}
     InfSymTridiagonal() = SymTridiagonal(InfVec(), InfVec())
     InfTridiagonal() = Tridiagonal(InfVec(), InfVec(), InfVec())

--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -97,14 +97,14 @@ module InfiniteArrays
     ArrayLayouts.MemoryLayout(::Type{<:InfMat}) = DenseColumnMajor()
     Base.copy(A::InfMat) = InfMat(copy(A.vec))
 
-    const InfSymTridiagonal = SymTridiagonal{Float64,InfVec{Xoshiro}}
-    const InfTridiagonal = Tridiagonal{Float64,InfVec{Xoshiro}}
-    const InfBidiagonal = Bidiagonal{Float64,InfVec{Xoshiro}}
+    const InfSymTridiagonal = SymTridiagonal{Float64,<:InfVec}
+    const InfTridiagonal = Tridiagonal{Float64,<:InfVec}
+    const InfBidiagonal = Bidiagonal{Float64,<:InfVec}
     const InfUnitUpperTriangular = UnitUpperTriangular{Float64,InfMat{Xoshiro}}
     const InfUnitLowerTriangular = UnitLowerTriangular{Float64,InfMat{Xoshiro}}
     const InfUpperTriangular = UpperTriangular{Float64,InfMat{Xoshiro}}
     const InfLowerTriangular = LowerTriangular{Float64,InfMat{Xoshiro}}
-    const InfDiagonal = Diagonal{Float64,InfVec{Xoshiro}}
+    const InfDiagonal = Diagonal{Float64,<:InfVec}
     InfSymTridiagonal() = SymTridiagonal(InfVec(), InfVec())
     InfTridiagonal() = Tridiagonal(InfVec(), InfVec(), InfVec())
     InfBidiagonal(uplo) = Bidiagonal(InfVec(), InfVec(), uplo)

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -1,7 +1,7 @@
 module TestLayoutArray
 
-using ArrayLayouts, LinearAlgebra, FillArrays, Test, SparseArrays
-using ArrayLayouts: sub_materialize, MemoryLayout, ColumnNorm, RowMaximum, CRowMaximum, @_layoutlmul
+using ArrayLayouts, LinearAlgebra, FillArrays, Test, SparseArrays, Random
+using ArrayLayouts: sub_materialize, MemoryLayout, ColumnNorm, RowMaximum, CRowMaximum, @_layoutlmul, Mul
 import ArrayLayouts: triangulardata
 
 struct MyMatrix <: LayoutMatrix{Float64}
@@ -615,6 +615,28 @@ triangulardata(A::MyUpperTriangular) = triangulardata(A.A)
 
     @test MyMatrix(A) / U ≈ A / U
     VERSION >= v"1.9" && @test U / MyMatrix(A) ≈ U / A
+end
+
+#### Tests needed for InfiniteRandomArrays.jl (see https://github.com/DanielVandH/InfiniteRandomArrays.jl/issues/5) 
+include("infinitearrays.jl")
+using .InfiniteArrays
+
+@testset "* for infinite layouts" begin
+    tup = InfSymTridiagonal(), InfTridiagonal(), InfBidiagonal('U'),
+        InfBidiagonal('L'),
+        InfUnitUpperTriangular(), InfUnitLowerTriangular(),
+        InfUpperTriangular(), InfLowerTriangular(), InfDiagonal()
+    symtri, tri, bidiagup, bidiaglo, unitup, unitlo, up, lo, di = tup;
+    for A in tup
+        A_up, A_lo = A isa Union{UpperTriangular,UnitUpperTriangular}, A isa Union{LowerTriangular,UnitLowerTriangular}
+        for B in tup
+            B_up, B_lo = B isa Union{UpperTriangular,UnitUpperTriangular}, B isa Union{LowerTriangular,UnitLowerTriangular}
+            ((A_up && B_lo) || (A_lo && B_up)) && continue
+            C = A * B 
+            _C = [C[i, j] for i in 1:100, j in 1:100] # else we need to fix the C[1:100, 1:100] MethodError from _getindex(::Mul, ...). This is easier
+            @test _C ≈ Matrix(A[1:100, 1:102]) * Matrix(B[1:102, 1:100])
+        end
+    end
 end
 
 end

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -617,7 +617,7 @@ triangulardata(A::MyUpperTriangular) = triangulardata(A.A)
     VERSION >= v"1.9" && @test U / MyMatrix(A) ≈ U / A
 end
 
-#### Tests needed for InfiniteRandomArrays.jl (see https://github.com/DanielVandH/InfiniteRandomArrays.jl/issues/5) 
+# Tests needed for InfiniteRandomArrays.jl (see https://github.com/DanielVandH/InfiniteRandomArrays.jl/issues/5) 
 include("infinitearrays.jl")
 using .InfiniteArrays
 
@@ -626,7 +626,6 @@ using .InfiniteArrays
         InfBidiagonal('L'),
         InfUnitUpperTriangular(), InfUnitLowerTriangular(),
         InfUpperTriangular(), InfLowerTriangular(), InfDiagonal()
-    symtri, tri, bidiagup, bidiaglo, unitup, unitlo, up, lo, di = tup;
     for A in tup
         A_up, A_lo = A isa Union{UpperTriangular,UnitUpperTriangular}, A isa Union{LowerTriangular,UnitLowerTriangular}
         for B in tup

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -625,10 +625,10 @@ using .InfiniteArrays
     tup = InfSymTridiagonal(), InfTridiagonal(), InfBidiagonal('U'),
         InfBidiagonal('L'),
         InfUnitUpperTriangular(), InfUnitLowerTriangular(),
-        InfUpperTriangular(), InfLowerTriangular(), InfDiagonal()
-    for A in tup
+        InfUpperTriangular(), InfLowerTriangular(), InfDiagonal();
+    for (i, A) in enumerate(tup)
         A_up, A_lo = A isa Union{UpperTriangular,UnitUpperTriangular}, A isa Union{LowerTriangular,UnitLowerTriangular}
-        for B in tup
+        for (j, B) in enumerate(tup)
             B_up, B_lo = B isa Union{UpperTriangular,UnitUpperTriangular}, B isa Union{LowerTriangular,UnitLowerTriangular}
             ((A_up && B_lo) || (A_lo && B_up)) && continue
             C = A * B 


### PR DESCRIPTION
Need this to support multiplication between infinite matrices, as found in https://github.com/DanielVandH/InfiniteRandomArrays.jl/issues/5.

To make sure the methods are being tested properly, I extended the minimal InfiniteArrays.jl module in the tests to include a (hopefully minimal) definition of an infinite vector and an infinite matrix, and the resulting named matrices to mimic those from InfiniteRandomMatrices.jl. 

`InfVec` and `InfMat` were initially just matrices which returned the indices, e.g. `InfVec()[i] = i`, but I wanted to be sure the methods were properly copying the data and accessing the correct entries, so I convert it into a random vector.