### PR TITLE
Resolve stack-overflow in Diagonal*Bidiagonal and (Sym)Tridiagonal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.10.1"
+version = "1.10.2"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -57,12 +57,12 @@ copy(M::Rdiv{<:DiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = diagona
 
 
 ## bi/tridiagonal copy
-copy(M::Rmul{<:BidiagonalLayout,<:DiagonalLayout}) = convert(Bidiagonal, M.A) * M.B
-copy(M::Lmul{<:DiagonalLayout,<:BidiagonalLayout}) = M.A * convert(Bidiagonal, M.B)
-copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout}) = convert(Tridiagonal, M.A) * M.B
-copy(M::Lmul{<:DiagonalLayout,<:TridiagonalLayout}) = M.A * convert(Tridiagonal, M.B)
-copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout}) = convert(SymTridiagonal, M.A) * M.B
-copy(M::Lmul{<:DiagonalLayout,<:SymTridiagonalLayout}) = M.A * convert(SymTridiagonal, M.B)
+copy(M::Rmul{<:BidiagonalLayout,<:DiagonalLayout}) = convert(Bidiagonal, M.A) .* permutedims(parent(convert(Diagonal, M.B)))
+copy(M::Lmul{<:DiagonalLayout,<:BidiagonalLayout}) = parent(convert(Diagonal, M.A)) .* convert(Bidiagonal, M.B)
+copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout}) = convert(Tridiagonal, M.A) .* permutedims(parent(convert(Diagonal, M.B)))
+copy(M::Lmul{<:DiagonalLayout,<:TridiagonalLayout}) = parent(convert(Diagonal, M.A)) .* convert(Tridiagonal, M.B)
+copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout}) = convert(SymTridiagonal, M.A) .* permutedims(parent(convert(Diagonal, M.B)))
+copy(M::Lmul{<:DiagonalLayout,<:SymTridiagonalLayout}) = parent(convert(Diagonal, M.A)) .* convert(SymTridiagonal, M.B)
 
 copy(M::Lmul{DiagonalLayout{OnesLayout}}) = _copy_oftype(M.B, eltype(M))
 copy(M::Lmul{DiagonalLayout{OnesLayout},<:DiagonalLayout}) = Diagonal(_copy_oftype(diagonaldata(M.B), eltype(M)))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -57,12 +57,36 @@ copy(M::Rdiv{<:DiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = diagona
 
 
 ## bi/tridiagonal copy
-copy(M::Rmul{<:BidiagonalLayout,<:DiagonalLayout}) = convert(Bidiagonal, M.A) .* permutedims(parent(convert(Diagonal, M.B)))
-copy(M::Lmul{<:DiagonalLayout,<:BidiagonalLayout}) = parent(convert(Diagonal, M.A)) .* convert(Bidiagonal, M.B)
-copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout}) = convert(Tridiagonal, M.A) .* permutedims(parent(convert(Diagonal, M.B)))
-copy(M::Lmul{<:DiagonalLayout,<:TridiagonalLayout}) = parent(convert(Diagonal, M.A)) .* convert(Tridiagonal, M.B)
-copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout}) = convert(SymTridiagonal, M.A) .* permutedims(parent(convert(Diagonal, M.B)))
-copy(M::Lmul{<:DiagonalLayout,<:SymTridiagonalLayout}) = parent(convert(Diagonal, M.A)) .* convert(SymTridiagonal, M.B)
+# hack around the fact that a SymTridiagonal isn't fully mutable
+_similar(A) = similar(A)
+_similar(A::SymTridiagonal) = similar(Tridiagonal(A.ev, A.dv, A.ev))
+_copy_diag(M::T, ::T) where {T<:Rmul} = copyto!(_similar(M.A), M)
+_copy_diag(M::T, ::T) where {T<:Lmul} = copyto!(_similar(M.B), M)
+_copy_diag(M, _) = copy(M)
+function copy(M::Rmul{<:BidiagonalLayout,<:DiagonalLayout})
+    A = convert(Bidiagonal, M.A)
+    _copy_diag(Rmul(A, M.B), M)
+end
+function copy(M::Lmul{<:DiagonalLayout,<:BidiagonalLayout})
+    B = convert(Bidiagonal, M.B)
+    _copy_diag(Lmul(M.A, B), M)
+end
+function copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout})
+    A = convert(Tridiagonal, M.A)
+    _copy_diag(Rmul(A, M.B), M)
+end
+function copy(M::Lmul{<:DiagonalLayout,<:TridiagonalLayout})
+    B = convert(Tridiagonal, M.B)
+    _copy_diag(Lmul(M.A, B), M)
+end
+function copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout})
+    A = convert(SymTridiagonal, M.A)
+    _copy_diag(Rmul(A, M.B), M)
+end
+function copy(M::Lmul{<:DiagonalLayout,<:SymTridiagonalLayout})
+    B = convert(SymTridiagonal, M.B)
+    _copy_diag(Lmul(M.A, B), M)
+end
 
 copy(M::Lmul{DiagonalLayout{OnesLayout}}) = _copy_oftype(M.B, eltype(M))
 copy(M::Lmul{DiagonalLayout{OnesLayout},<:DiagonalLayout}) = Diagonal(_copy_oftype(diagonaldata(M.B), eltype(M)))

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -106,8 +106,8 @@ Base.copy(A::MyVector) = MyVector(copy(A.A))
             @test_throws ErrorException qr!(A)
             @test lu!(copy(A)).factors ≈ lu(A.A).factors
             b = randn(5)
-            @test A \ b == A.A \ b == A.A \ MyVector(b) == ldiv!(lu(A.A), copy(MyVector(b)))
-            @test A \ b == ldiv!(lu(A), copy(MyVector(b))) == ldiv!(lu(A), copy(b))
+            @test A \ b == A.A \ b == A.A \ MyVector(b) == ldiv!(lu(A.A), copy(b))
+            @test A \ b == ldiv!(lu(A), copy(b))
             @test lu(A).L == lu(A.A).L
             @test lu(A).U == lu(A.A).U
             @test lu(A).p == lu(A.A).p

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -122,7 +122,7 @@ Base.copy(A::MyVector) = MyVector(copy(A.A))
             @test cholesky!(deepcopy(S), CRowMaximum()).U ≈ cholesky(Matrix(S), CRowMaximum()).U
             @test cholesky(S) \ b ≈ cholesky(Matrix(S)) \ b ≈ cholesky(Matrix(S)) \ MyVector(b)
             @test cholesky(S, CRowMaximum()) \ b ≈ cholesky(Matrix(S), CRowMaximum()) \ b
-            @test cholesky(S, CRowMaximum()) \ b ≈ ldiv!(cholesky(Matrix(S), CRowMaximum()), copy(MyVector(b)))
+            @test cholesky(S, CRowMaximum()) \ b ≈ ldiv!(cholesky(Matrix(S), CRowMaximum()), copy(b))
             @test cholesky(S) \ b ≈ Matrix(S) \ b ≈ Symmetric(Matrix(S)) \ b
             @test cholesky(S) \ b ≈ Symmetric(Matrix(S)) \ MyVector(b)
             if VERSION >= v"1.9"

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -147,16 +147,7 @@ Base.copy(A::MyVector) = MyVector(copy(A.A))
 
             @testset "ldiv!" begin
                 c = MyVector(randn(5))
-                # if VERSION < v"1.9"
-                #     @test_broken ldiv!(lu(A), MyVector(copy(c))) ≈ A \ c
-                # else
                 @test ldiv!(lu(A), MyVector(copy(c))) ≈ A \ c
-                # end
-                # if VERSION < v"1.9" || VERSION >= v"1.10-"
-                #     @test_throws ErrorException ldiv!(qr(A), MyVector(copy(c)))
-                # else
-                #     @test_throws MethodError ldiv!(qr(A), MyVector(copy(c)))
-                # end
                 @test_throws ErrorException ldiv!(eigen(randn(5,5)), c)
                 @test ArrayLayouts.ldiv!(svd(A.A), Vector(c)) ≈ ArrayLayouts.ldiv!(similar(c), svd(A.A), c) ≈ A \ c
                 if VERSION ≥ v"1.8"

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -337,6 +337,22 @@ MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
         @test B̃\D ≈ B̃\Matrix(D)
         @test D\D̃ ≈ D̃\D
         @test B̃/D ≈ B̃/Matrix(D)
+
+        @testset "Diagonal * Bidiagonal/Tridiagonal with structured diags" begin
+            n = size(D,1)
+            B = Bidiagonal(map(MyVector, (rand(n), rand(n-1)))..., :U)
+            S = SymTridiagonal(map(MyVector, (rand(n), rand(n-1)))...)
+            T = Tridiagonal(map(MyVector, (rand(n-1), rand(n), rand(n-1)))...)
+            DA, BA, SA, TA = map(Array, (D, B, S, T))
+            @test D * B ≈ DA * BA
+            @test B * D ≈ BA * DA
+            if VERSION >= v"1.12.0-DEV.824"
+                @test D * S ≈ DA * SA
+                @test D * T ≈ DA * TA
+                @test S * D ≈ SA * DA
+                @test T * D ≈ TA * DA
+            end
+        end
     end
 
     @testset "Adj/Trans" begin


### PR DESCRIPTION
Currently, there are method ambiguities on v1.10, because of which these paths were not being tested. These ambiguities are resolved on the currently nightly, which reveals a stack-overflow in these methods. This arises because an operation like
```julia
(D::Diagonal{<:Any, <:LayoutVector}) * (B::Bidiagonal{<:Any, <:LayoutVector})
```
internally calls
```julia
copy(M::Lmul{<:DiagonalLayout,<:BidiagonalLayout})
```
but this method was calling `D * B` again, leading to a cycle. To avoid this, we now broadcast `D.diag` over the other matrix. The added tests all work on nightly where there are no method ambiguities anymore, and the `Bidiagonal` ones work on current versions as well.