### PR TITLE
Disambiguate FillMatrix * LayoutVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.10.2"
+version = "1.10.3"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -348,7 +348,7 @@ end
 *(A::Transpose{<:Any,<:LayoutVector}, B::Transpose{<:Any,<:LayoutMatrix}) = mul(A,B)
 
 # Disambiguation with FillArrays
-*(A::AbstractFill{<:Any,2}, B::LayoutVector) = @invoke *(A::AbstractFill{<:Any,2}, B::AbstractVector)
+*(A::AbstractFill{<:Any,2}, B::LayoutVector) = mul(A, B)
 
 ## special routines introduced in v0.9. We need to avoid these to support ∞-arrays
 

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -347,6 +347,9 @@ end
 *(A::Transpose{<:Any,<:LayoutVector}, B::Adjoint{<:Any,<:LayoutMatrix}) = mul(A,B)
 *(A::Transpose{<:Any,<:LayoutVector}, B::Transpose{<:Any,<:LayoutMatrix}) = mul(A,B)
 
+# Disambiguation with FillArrays
+*(A::AbstractFill{<:Any,2}, B::LayoutVector) = @invoke *(A::AbstractFill{<:Any,2}, B::AbstractVector)
+
 ## special routines introduced in v0.9. We need to avoid these to support ∞-arrays
 
 *(x::Adjoint{<:Any,<:LayoutVector},   D::Diagonal{<:Any,<:LayoutVector}) = mul(x, D)

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -349,6 +349,8 @@ end
 
 # Disambiguation with FillArrays
 *(A::AbstractFill{<:Any,2}, B::LayoutVector) = invoke(*, Tuple{AbstractFill{<:Any,2}, AbstractVector}, A, B)
+*(A::Adjoint{<:Any, <:LayoutVector}, B::AbstractFill{<:Any,2}) = invoke(*, Tuple{Adjoint{<:Any, <:AbstractVector}, AbstractFill{<:Any,2}}, A, B)
+*(A::Transpose{<:Any, <:LayoutVector}, B::AbstractFill{<:Any,2}) = invoke(*, Tuple{Transpose{<:Any, <:AbstractVector}, AbstractFill{<:Any,2}}, A, B)
 
 ## special routines introduced in v0.9. We need to avoid these to support ∞-arrays
 

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -348,7 +348,7 @@ end
 *(A::Transpose{<:Any,<:LayoutVector}, B::Transpose{<:Any,<:LayoutMatrix}) = mul(A,B)
 
 # Disambiguation with FillArrays
-*(A::AbstractFill{<:Any,2}, B::LayoutVector) = @invoke *(A::AbstractFill{<:Any,2}, B::AbstractVector)
+*(A::AbstractFill{<:Any,2}, B::LayoutVector) = invoke(*, Tuple{AbstractFill{<:Any,2}, AbstractVector}, A, B)
 
 ## special routines introduced in v0.9. We need to avoid these to support ∞-arrays
 

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -348,7 +348,7 @@ end
 *(A::Transpose{<:Any,<:LayoutVector}, B::Transpose{<:Any,<:LayoutMatrix}) = mul(A,B)
 
 # Disambiguation with FillArrays
-*(A::AbstractFill{<:Any,2}, B::LayoutVector) = mul(A, B)
+*(A::AbstractFill{<:Any,2}, B::LayoutVector) = @invoke *(A::AbstractFill{<:Any,2}, B::AbstractVector)
 
 ## special routines introduced in v0.9. We need to avoid these to support ∞-arrays
 

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -638,4 +638,13 @@ using .InfiniteArrays
     end
 end
 
+@testset "disambiguation with FillArrays" begin
+    v = [1,2,3]
+    lv = MyVector(v)
+    F = Fill(2, 3, 3)
+    @test F * lv == F * v
+    @test lv' * F == v' * F
+    @test transpose(lv) * F == transpose(v) * F
+end
+
 end


### PR DESCRIPTION
We may potentially go either way. In this, I have chosen to return a `FillArray`, as this avoids allocating the destination.