### PR TITLE
Set julia compat to v1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "1.10.4"
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -18,14 +17,14 @@ ArrayLayoutsSparseArraysExt = "SparseArrays"
 Aqua = "0.8"
 FillArrays = "1.2.1"
 Infinities = "0.1"
-LinearAlgebra = "1.6"
+LinearAlgebra = "1"
 Quaternions = "0.7"
-Random = "1.6"
-SparseArrays = "1.6"
+Random = "1"
+SparseArrays = "1"
 StableRNGs = "1"
 StaticArrays = "1"
-Test = "1.6"
-julia = "1.6"
+Test = "1"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "1.10.4"
+version = "1.11.0"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -425,8 +425,4 @@ Base.typed_hcat(::Type{T}, A::LayoutVecOrMats, B::LayoutVecOrMats, C::AbstractVe
 Base.typed_vcat(::Type{T}, A::AbstractVecOrMat, B::LayoutVecOrMats, C::AbstractVecOrMat...) where T = typed_vcat(T, A, B, C...)
 Base.typed_hcat(::Type{T}, A::AbstractVecOrMat, B::LayoutVecOrMats, C::AbstractVecOrMat...) where T = typed_hcat(T, A, B, C...)
 
-if !isdefined(Base, :get_extension)
-    include("../ext/ArrayLayoutsSparseArraysExt.jl")
-end
-
 end # module


### PR DESCRIPTION
Since v1.10 is the LTS now, we may focus development only on v1.10+. Versions of this pacakge <v1.11 would continue to be compatible with julia v1.6.