### PR TITLE
Include infinitearrays only once in tests

### DIFF
--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -2,7 +2,7 @@
 # https://github.com/JuliaLang/julia/blob/master/test/testhelpers/InfiniteArrays.jl
 module InfiniteArrays
     using Infinities, LinearAlgebra, Random
-    using ..ArrayLayouts: ArrayLayouts, LayoutVector, LayoutMatrix, Mul, DenseColumnMajor
+    using ArrayLayouts: ArrayLayouts, LayoutVector, LayoutMatrix, Mul, DenseColumnMajor
     export OneToInf,
         InfSymTridiagonal,
         InfTridiagonal,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ end
 
 Random.seed!(0)
 
+include("infinitearrays.jl")
 include("test_utils.jl")
 include("test_layouts.jl")
 include("test_muladd.jl")

--- a/test/test_cumsum.jl
+++ b/test/test_cumsum.jl
@@ -1,8 +1,7 @@
 module TestCumsum
 
 using ArrayLayouts, Test, Infinities
-
-include("infinitearrays.jl")
+using ..InfiniteArrays
 
 cmpop(p) = isinteger(real(first(p))) && isinteger(real(step(p))) ? (==) : (≈)
 

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -643,8 +643,7 @@ triangulardata(A::MyUpperTriangular) = triangulardata(A.A)
 end
 
 # Tests needed for InfiniteRandomArrays.jl (see https://github.com/DanielVandH/InfiniteRandomArrays.jl/issues/5) 
-include("infinitearrays.jl")
-using .InfiniteArrays
+using ..InfiniteArrays
 
 @testset "* for infinite layouts" begin
     tup = InfSymTridiagonal(), InfTridiagonal(), InfBidiagonal('U'),

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -1,8 +1,8 @@
 module TestLayoutArray
 
 using ArrayLayouts, LinearAlgebra, FillArrays, Test, SparseArrays, Random
-using ArrayLayouts: sub_materialize, MemoryLayout, ColumnNorm, RowMaximum, CRowMaximum, @_layoutlmul, Mul
-import ArrayLayouts: triangulardata
+using ArrayLayouts: sub_materialize, ColumnNorm, RowMaximum, CRowMaximum, @_layoutlmul, Mul
+import ArrayLayouts: triangulardata, MemoryLayout
 import LinearAlgebra: Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal
 
 struct MyMatrix{T,M<:AbstractMatrix{T}} <: LayoutMatrix{T}


### PR DESCRIPTION
This ensures that there are no method overwritten warnings in tests